### PR TITLE
[remote mining p0] Add remote miner interface

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -35,10 +35,24 @@ var (
 	ErrInvalidPoW        = errors.New("invalid proof-of-work")
 )
 
+// MiningWork represents the params of mining work.
+type MiningWork struct {
+	HeaderHash common.Hash
+	Number     *big.Int
+	Difficulty *big.Int
+}
+
+// MiningResult represents the found digest and result bytes.
+type MiningResult struct {
+	Digest []byte
+	Result []byte
+	Nonce  uint64
+}
+
 // MiningSpec contains a PoW algo's basic info and hash algo
 type MiningSpec struct {
 	Name     string
-	HashAlgo func(hash []byte, nonce uint64) (digest []byte, result []byte)
+	HashAlgo func(hash []byte, nonce uint64) MiningResult
 }
 
 // CommonEngine contains the common parts for consensus engines, where engine-specific
@@ -48,6 +62,14 @@ type CommonEngine struct {
 	hashrate metrics.Meter
 	// For reusing existing functions
 	ethash *ethash.Ethash
+}
+
+// PoW is the quarkchain version of PoW consensus engine, with a conveninent method for
+// remote miners.
+type PoW interface {
+	ethconsensus.PoW
+
+	FindNonce(work MiningWork, results chan<- MiningResult, stop <-chan struct{}) error
 }
 
 // SealHash returns the hash of a block prior to it being sealed.
@@ -131,17 +153,15 @@ func (c *CommonEngine) VerifyHeaders(
 	return nil, errorsOut
 }
 
-// Seal generates a new block for the given input block with the local miner's
-// seal place on top.
-func (c *CommonEngine) Seal(
-	chain ethconsensus.ChainReader,
-	block *types.Block,
-	results chan<- *types.Block,
+// FindNonce finds the desired nonce and mixhash for a given block header.
+func (c *CommonEngine) FindNonce(
+	work MiningWork,
+	results chan<- MiningResult,
 	stop <-chan struct{},
 ) error {
 
 	abort := make(chan struct{})
-	found := make(chan *types.Block)
+	found := make(chan MiningResult)
 
 	// Random number generator.
 	seed, err := crand.Int(crand.Reader, big.NewInt(math.MaxInt64))
@@ -157,21 +177,17 @@ func (c *CommonEngine) Seal(
 		pend.Add(1)
 		go func(id int, nonce uint64) {
 			defer pend.Done()
-			c.mine(block, id, nonce, abort, found)
+			c.mine(work, id, nonce, abort, found)
 		}(i, uint64(randGen.Uint64()))
 	}
 
 	go func() {
-		var result *types.Block
+		var result MiningResult
 		select {
 		case <-stop:
 			close(abort)
 		case result = <-found:
-			select {
-			case results <- result:
-			default:
-				log.Warn("Sealing result is not read by miner", "mode", "local", "sealhash", c.SealHash(block.Header()))
-			}
+			results <- result
 			close(abort)
 		}
 		pend.Wait()
@@ -179,18 +195,54 @@ func (c *CommonEngine) Seal(
 	return nil
 }
 
-func (c *CommonEngine) mine(
+// Seal generates a new block for the given input block with the local miner's
+// seal place on top.
+func (c *CommonEngine) Seal(
+	chain ethconsensus.ChainReader,
 	block *types.Block,
+	results chan<- *types.Block,
+	stop <-chan struct{},
+) error {
+
+	abort := make(chan struct{})
+	found := make(chan MiningResult)
+	header := block.Header()
+	work := MiningWork{HeaderHash: c.SealHash(header), Number: header.Number, Difficulty: header.Difficulty}
+	if err := c.FindNonce(work, found, abort); err != nil {
+		return err
+	}
+	// Convert found header to block
+	go func() {
+		var result MiningResult
+		select {
+		case <-stop:
+			close(abort)
+		case result = <-found:
+			header = types.CopyHeader(header)
+			header.Nonce = types.EncodeNonce(result.Nonce)
+			header.MixDigest = common.BytesToHash(result.Digest)
+			select {
+			case results <- block.WithSeal(header):
+			default:
+				log.Warn("Sealing result is not read by miner", "mode", "local", "sealhash", work.HeaderHash)
+			}
+			close(abort)
+		}
+	}()
+	return nil
+}
+
+func (c *CommonEngine) mine(
+	work MiningWork,
 	id int,
 	startNonce uint64,
 	abort chan struct{},
-	found chan *types.Block,
+	found chan MiningResult,
 ) {
 
 	var (
-		header   = block.Header()
-		hash     = c.SealHash(header).Bytes()
-		target   = new(big.Int).Div(two256, header.Difficulty)
+		hash     = work.HeaderHash.Bytes()
+		target   = new(big.Int).Div(two256, work.Difficulty)
 		attempts = int64(0)
 		nonce    = startNonce
 	)
@@ -209,15 +261,12 @@ search:
 				c.hashrate.Mark(attempts)
 				attempts = 0
 			}
-			digest, result := c.spec.HashAlgo(hash, nonce)
-			if new(big.Int).SetBytes(result).Cmp(target) <= 0 {
+			miningRes := c.spec.HashAlgo(hash, nonce)
+			if new(big.Int).SetBytes(miningRes.Result).Cmp(target) <= 0 {
 				// Nonce found
-				header = types.CopyHeader(header)
-				header.Nonce = types.EncodeNonce(nonce)
-				header.MixDigest = common.BytesToHash(digest)
 
 				select {
-				case found <- block.WithSeal(header):
+				case found <- miningRes:
 					logger.Trace("Nonce found and reported", "minerName", c.spec.Name, "attempts", nonce-startNonce, "nonce", nonce)
 				case <-abort:
 					logger.Trace("Nonce nonce found but discarded", "minerName", c.spec.Name, "attempts", nonce-startNonce, "nonce", nonce)

--- a/consensus/qkchash/qkchash.go
+++ b/consensus/qkchash/qkchash.go
@@ -16,6 +16,7 @@ import (
 // QKCHash is a consensus engine implementing PoW with qkchash algo.
 // See the interface definition:
 // https://github.com/ethereum/go-ethereum/blob/9e9fc87e70accf2b81be8772ab2ab0c914e95666/consensus/consensus.go#L111
+// Implements consensus.Pow
 type QKCHash struct {
 	commonEngine *consensus.CommonEngine
 	// For reusing existing functions
@@ -82,15 +83,15 @@ func (q *QKCHash) Close() error {
 	return nil
 }
 
-func (q *QKCHash) hashAlgo(hash []byte, nonce uint64) (digest, result []byte) {
+func (q *QKCHash) hashAlgo(hash []byte, nonce uint64) consensus.MiningResult {
 	// TOOD: cache may depend on block, so a LRU-stype cache could be helpful
 	if len(q.cache.ls) == 0 {
 		q.cache = generateQKCCache(cacheEntryCnt, cacheSeed)
 	}
 	nonceBytes := make([]byte, 8)
 	binary.LittleEndian.PutUint64(nonceBytes, nonce)
-	digest, result = qkcHash(hash, nonceBytes, q.cache)
-	return
+	digest, result := qkcHash(hash, nonceBytes, q.cache)
+	return consensus.MiningResult{Digest: digest, Result: result, Nonce: nonce}
 }
 
 // New returns a QKCHash scheme.

--- a/consensus/qkchash/sealer.go
+++ b/consensus/qkchash/sealer.go
@@ -38,13 +38,12 @@ func (q *QKCHash) VerifySeal(chain ethconsensus.ChainReader, header *types.Heade
 		return consensus.ErrInvalidDifficulty
 	}
 
-	digest, result := q.hashAlgo(q.SealHash(header).Bytes(), header.Nonce.Uint64())
-
-	if !bytes.Equal(header.MixDigest[:], digest) {
+	miningRes := q.hashAlgo(q.SealHash(header).Bytes(), header.Nonce.Uint64())
+	if !bytes.Equal(header.MixDigest[:], miningRes.Digest) {
 		return consensus.ErrInvalidMixDigest
 	}
 	target := new(big.Int).Div(two256, header.Difficulty)
-	if new(big.Int).SetBytes(result).Cmp(target) > 0 {
+	if new(big.Int).SetBytes(miningRes.Result).Cmp(target) > 0 {
 		return consensus.ErrInvalidPoW
 	}
 	return nil


### PR DESCRIPTION
...namely, `consensus.PoW.FindNonce` method, which decouples actual block data and necessary work params (hash, height and diff)