### PR TITLE
Fix unmarshalling reward tax rate to rational number

### DIFF
--- a/cluster/config/cluster_config.go
+++ b/cluster/config/cluster_config.go
@@ -132,7 +132,12 @@ func (q *QuarkChainConfig) UnmarshalJSON(input []byte) error {
 		return err
 	}
 	*q = QuarkChainConfig(jsonConfig.QuarkChainConfigAlias)
-	q.RewardTaxRate = new(big.Rat).SetFloat64(jsonConfig.RewardTaxRate)
+	rate := fmt.Sprintf("%f", jsonConfig.RewardTaxRate)
+	var success bool
+	q.RewardTaxRate, success = new(big.Rat).SetString(rate)
+	if !success {
+		return errors.New("failed to unmarshal reward tax rate")
+	}
 	return nil
 }
 

--- a/cluster/config/config_test.go
+++ b/cluster/config/config_test.go
@@ -31,8 +31,8 @@ var tomlSettings = toml.Config{
 }
 
 func TestClusterConfig(t *testing.T) {
-	cluster := NewClusterConfig()
-	jsonConfig, err := json.Marshal(cluster)
+	clusterConfig := NewClusterConfig()
+	jsonConfig, err := json.Marshal(clusterConfig)
 	if err != nil {
 		t.Fatalf("cluster struct marshal error: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestClusterConfig(t *testing.T) {
 	var c ClusterConfig
 	err = json.Unmarshal(jsonConfig, &c)
 	if err != nil {
-		t.Fatalf("UnMarsshal cluster config error: %v", err)
+		t.Fatalf("UnMarshal cluster config error: %v", err)
 	}
 	if c.DbPathRoot != "./data" {
 		t.Fatalf("db path root error")
@@ -86,6 +86,13 @@ func TestClusterConfig(t *testing.T) {
 	if len(initializeIds) != 0 {
 		t.Fatalf("the list of ids should be empty.")
 	}
+}
+
+func TestMarshallingRationalNumber(t *testing.T) {
+	jsonSource := []byte(`{"REWARD_TAX_RATE": 0.333}`)
+	var c QuarkChainConfig
+	assert.NoError(t, json.Unmarshal(jsonSource, &c))
+	assert.Equal(t, c.RewardTaxRate.String(), "333/1000")
 }
 
 func TestSlaveConfig(t *testing.T) {


### PR DESCRIPTION
@mask-pp thanks for pointing out this error, `big.Rat.SetFloat64` will have precision problems

added a test to prevent future errors