### PR TITLE
Add extra sanity check for minor block validation

### DIFF
--- a/core/minorheaderchain.go
+++ b/core/minorheaderchain.go
@@ -193,7 +193,7 @@ func (hc *HeaderChain) WriteHeader(header *types.MinorBlockHeader) (status Write
 	return
 }
 
-// WhCallback is a callback function for inserting individual Headers.
+// MinorWhCallback is a callback function for inserting individual Headers.
 // A callback is used for two reasons: first, in a LightChain, status should be
 // processed and light chain events sent, while in a MinorBlockChain this is not
 // necessary since chain events are sent after inserting blocks. Second, the

--- a/core/types/interface.go
+++ b/core/types/interface.go
@@ -1,9 +1,10 @@
 package types
 
 import (
+	"math/big"
+
 	"github.com/QuarkChain/goquarkchain/account"
 	"github.com/ethereum/go-ethereum/common"
-	"math/big"
 )
 
 type IHeader interface {
@@ -22,11 +23,9 @@ type IHeader interface {
 	SetDifficulty(*big.Int)
 	SetNonce(uint64)
 	GetMixDigest() common.Hash
-	ValidateHeader() error
 }
 
 type IBlock interface {
-	ValidateBlock() error
 	Hash() common.Hash
 	NumberU64() uint64
 	IHeader() IHeader

--- a/core/types/minorblock.go
+++ b/core/types/minorblock.go
@@ -2,14 +2,14 @@
 package types
 
 import (
-	"errors"
-	"github.com/QuarkChain/goquarkchain/account"
-	"github.com/QuarkChain/goquarkchain/serialize"
-	"github.com/ethereum/go-ethereum/common"
 	"math/big"
 	"sync/atomic"
 	"time"
 	"unsafe"
+
+	"github.com/QuarkChain/goquarkchain/account"
+	"github.com/QuarkChain/goquarkchain/serialize"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 //go:generate gencodec -type Header -field-override headerMarshaling -out gen_header_json.go
@@ -95,13 +95,6 @@ func (h *MinorBlockHeader) GetBloom() Bloom {
 func (h *MinorBlockHeader) GetMixDigest() common.Hash { return h.MixDigest }
 
 func (h *MinorBlockHeader) NumberU64() uint64 { return h.Number }
-
-func (h *MinorBlockHeader) ValidateHeader() error {
-	if h.Number < 0 {
-		return errors.New("unexpected height")
-	}
-	return nil
-}
 
 func (h *MinorBlockHeader) SetExtra(data []byte) {
 	h.Extra = common.CopyBytes(data)
@@ -369,13 +362,6 @@ func (b *MinorBlock) Hash() common.Hash {
 	v := b.header.Hash()
 	b.hash.Store(v)
 	return v
-}
-func (b *MinorBlock) ValidateBlock() error {
-	if txHash := CalculateMerkleRoot(b.transactions); txHash != b.meta.TxHash {
-		return errors.New("incorrect merkle root")
-	}
-
-	return nil
 }
 
 func (b *MinorBlock) NumberU64() uint64 {

--- a/core/types/rootblock.go
+++ b/core/types/rootblock.go
@@ -4,7 +4,6 @@ package types
 
 import (
 	"crypto/ecdsa"
-	"errors"
 	"math/big"
 	"sync/atomic"
 	"time"
@@ -77,14 +76,6 @@ func (h *RootBlockHeader) GetExtra() []byte {
 func (h *RootBlockHeader) GetMixDigest() common.Hash { return h.MixDigest }
 
 func (h *RootBlockHeader) NumberU64() uint64 { return uint64(h.Number) }
-
-func (h *RootBlockHeader) ValidateHeader() error {
-	number := uint64(h.Number)
-	if number < 0 {
-		return errors.New("unexpected height")
-	}
-	return nil
-}
 
 func (h *RootBlockHeader) SetExtra(data []byte) {
 	h.Extra = common.CopyBytes(data)
@@ -163,14 +154,6 @@ type RootBlock struct {
 	// inter-peer block relay.
 	ReceivedAt   time.Time
 	ReceivedFrom interface{}
-}
-
-func (b *RootBlock) ValidateBlock() error {
-	if rootHash := CalculateMerkleRoot(b.MinorBlockHeaders()); rootHash != b.Header().MinorHeaderHash {
-		return errors.New("incorrect merkle root")
-	}
-
-	return nil
 }
 
 func (b *RootBlock) IHeader() IHeader {


### PR DESCRIPTION
1. removed `IHeader.ValidateHeader` and `IBlock.ValidateBlock` since they are run by validators
2. added extra root block pointer check in minor block validator to keep the logic consistent with py version