### PR TITLE
Skip fast path for mblock if its rblock confirmation is too old

### DIFF
--- a/cluster/sync/minor_task.go
+++ b/cluster/sync/minor_task.go
@@ -108,12 +108,17 @@ func NewMinorChainTask(
 			}
 
 			bc := b.(*core.MinorBlockChain)
+			// Do not download if the prev root block is not synced
 			rootBlockHeader := bc.GetRootBlockByHash(mTask.header.PrevRootBlockHash)
 			if rootBlockHeader == nil {
 				return true
 			}
+
 			// Do not download if the new header's confirmed root is lower then current root tip last header's confirmed root
 			// This means the minor block's root is a fork, which will be handled by master sync
+			if bc.GetMinorTip() == nil {
+				return false
+			}
 			confirmedRootHeader := bc.GetRootBlockByHash(bc.GetMinorTip().PrevRootBlockHash())
 			if confirmedRootHeader != nil && confirmedRootHeader.NumberU64() > rootBlockHeader.NumberU64() {
 				return true

--- a/cluster/sync/minor_task.go
+++ b/cluster/sync/minor_task.go
@@ -6,6 +6,7 @@ import (
 	"github.com/QuarkChain/goquarkchain/account"
 	"github.com/QuarkChain/goquarkchain/cluster/rpc"
 	qcom "github.com/QuarkChain/goquarkchain/common"
+	"github.com/QuarkChain/goquarkchain/core"
 	"github.com/QuarkChain/goquarkchain/core/types"
 	"github.com/QuarkChain/goquarkchain/p2p"
 	"github.com/ethereum/go-ethereum/common"
@@ -103,6 +104,18 @@ func NewMinorChainTask(
 		},
 		needSkip: func(b blockchain) bool {
 			if mTask.header.NumberU64() <= b.CurrentHeader().NumberU64() || b.HasBlock(mTask.header.Hash()) {
+				return true
+			}
+
+			bc := b.(*core.MinorBlockChain)
+			rootBlockHeader := bc.GetRootBlockByHash(mTask.header.PrevRootBlockHash)
+			if rootBlockHeader == nil {
+				return true
+			}
+			// Do not download if the new header's confirmed root is lower then current root tip last header's confirmed root
+			// This means the minor block's root is a fork, which will be handled by master sync
+			confirmedRootHeader := bc.GetRootBlockByHash(bc.GetMinorTip().PrevRootBlockHash())
+			if confirmedRootHeader != nil && confirmedRootHeader.NumberU64() > rootBlockHeader.NumberU64() {
 				return true
 			}
 			return false

--- a/cluster/sync/minor_task.go
+++ b/cluster/sync/minor_task.go
@@ -107,7 +107,10 @@ func NewMinorChainTask(
 				return true
 			}
 
-			bc := b.(*core.MinorBlockChain)
+			bc, ok := b.(*core.MinorBlockChain)
+			if !ok {
+				return false
+			}
 			// Do not download if the prev root block is not synced
 			rootBlockHeader := bc.GetRootBlockByHash(mTask.header.PrevRootBlockHash)
 			if rootBlockHeader == nil {

--- a/cluster/sync/minor_task_test.go
+++ b/cluster/sync/minor_task_test.go
@@ -196,14 +196,14 @@ func TestMinorChainTask(t *testing.T) {
 	// retMBlocks, retMHeaders = makeRootChains(retMBlocks[len(retMBlocks)-1], 1000, true)
 	retMBlocks, retMHeaders = makeMinorChains(retMBlocks[len(retMBlocks)-1], 1000, db, true)
 	for _, rh := range retMHeaders[1:] {
-		assert.False(t, mbc.HasBlock(rh.Hash()))
+		assert.False(t, bc.HasBlock(rh.Hash()))
 	}
 
 	mTask.header = retMHeaders[len(retMHeaders)-1]
 	p.retMHeaders, p.retMBlocks = append(p.retMHeaders[20:], retMHeaders...), append(p.retMBlocks[20:], retMBlocks...)
 	assert.NoError(t, mt.Run(bc))
 	for _, rh := range retMHeaders {
-		assert.True(t, mbc.HasBlock(rh.Hash()))
+		assert.True(t, bc.HasBlock(rh.Hash()))
 	}
 
 	assert.Equal(t, bc.CurrentHeader().NumberU64(), uint64(2000+20))


### PR DESCRIPTION
This prevents an attacker can send a minor block with a very old root confirmation.