### PR TITLE
Fix Action failure

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,7 +6,7 @@ jobs:
     container: quarkchaindocker/goquarkchain
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: daily-test
         run: |
           cd consensus/qkchash/native && make && cd -

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5,14 +5,10 @@ on: [push]
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
-    container: quarkchaindocker/goquarkchain:mainnet1.6.1
+    container: quarkchaindocker/goquarkchain:test1.6.1
 
     steps:
-      - name: upgrade
-        run: apt update && apt upgrade -y
-
-      - uses: actions/checkout@v3
-
+      - uses: actions/checkout@v4
       - name: daily-test
         run: |          
           cd consensus/qkchash/native && make && cd -

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,15 +1,20 @@
 name: go-test
+
 on: [push]
+
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
     container: quarkchaindocker/goquarkchain:mainnet1.6.1
 
     steps:
+      - name: upgrade
+        run: apt update && apt upgrade -y
+
       - uses: actions/checkout@v4
+
       - name: daily-test
-        run: |
-          apt update && apt upgrade -y
+        run: |          
           cd consensus/qkchash/native && make && cd -
           go vet ./...
           go test -timeout 1m ./... -gcflags=-l

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,10 +11,6 @@ jobs:
       - name: upgrade
         run: apt update && apt upgrade -y
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '20.x'
-
       - uses: actions/checkout@v3
 
       - name: daily-test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: '20.x'
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - name: daily-test
         run: |          

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,6 +11,10 @@ jobs:
       - name: upgrade
         run: apt update && apt upgrade -y
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+
       - uses: actions/checkout@v4
 
       - name: daily-test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,12 +3,13 @@ on: [push]
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
-    container: quarkchaindocker/goquarkchain
+    container: quarkchaindocker/goquarkchain:mainnet1.6.1
 
     steps:
       - uses: actions/checkout@v4
       - name: daily-test
         run: |
+          apt update && apt upgrade -y
           cd consensus/qkchash/native && make && cd -
           go vet ./...
           go test -timeout 1m ./... -gcflags=-l

--- a/.github/workflows/checkdb.yml
+++ b/.github/workflows/checkdb.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   download-snapshot-and-checkdb:
     runs-on: self-hosted
-    container: quarkchaindocker/goquarkchain
+    container: quarkchaindocker/goquarkchain:mainnet1.6.1
     timeout-minutes: 2880
 
     steps:

--- a/.github/workflows/checkdb.yml
+++ b/.github/workflows/checkdb.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 2880
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install Dependencies and Build
         run: |

--- a/.github/workflows/checkdb.yml
+++ b/.github/workflows/checkdb.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   download-snapshot-and-checkdb:
     runs-on: self-hosted
-    container: quarkchaindocker/goquarkchain:mainnet1.6.1
+    container: quarkchaindocker/goquarkchain:test1.6.1
     timeout-minutes: 2880
 
     steps:

--- a/.github/workflows/qkcli-test.yml
+++ b/.github/workflows/qkcli-test.yml
@@ -11,7 +11,7 @@ jobs:
           # In the future, add it as a submodule
           repository: QuarkChain/qkcli
           ref: master
-          token: ${{ secrets.QKCLI_PAT }}
+          token: ${{ secrets.GH_TOKEN }}
           path: qkcli
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/qkcli-test.yml
+++ b/.github/workflows/qkcli-test.yml
@@ -6,14 +6,14 @@ jobs:
   mnt-test-using-qkcli:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # In the future, add it as a submodule
           repository: QuarkChain/qkcli
           ref: master
           token: ${{ secrets.QKCLI_PAT }}
           path: qkcli
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         with:
           go-version: "~1.14.4"
       - run: go version

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y \
 
 # install rocksdb
 WORKDIR /code
-RUN git clone --branch v6.20.3 --single-branch https://github.com/facebook/rocksdb.git
+RUN git clone -b v6.20.3 --single-branch https://github.com/facebook/rocksdb.git
 WORKDIR /code/rocksdb
 RUN make shared_lib
 RUN make install-shared

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="goquarkchain"
 
 #prerequisite
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y \
 
 # install rocksdb
 WORKDIR /code
-RUN git clone -b v6.1.2 --single-branch https://github.com/facebook/rocksdb.git
+RUN git clone --branch v6.20.3 --single-branch https://github.com/facebook/rocksdb.git
 WORKDIR /code/rocksdb
 RUN make shared_lib
 RUN make install-shared


### PR DESCRIPTION
The goquarkchain action [build_and_test](https://github.com/QuarkChain/goquarkchain/actions/runs/13541146085/job/37842295698#logs) which use quarkchaindocker/goquarkchain will fail with error 
`/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version "GLIBC_2.28" not found (required by /__e/node20/bin/node)`. 
As the quarkchaindocker/goquarkchain is build on `ubuntu:18.04`, GLIBC_2.28 is not support. So update the docker using `ubuntu:20.04` and also update the rocksdb version from `v6.1.2` to `v6.20.3`.

**Changes**
1. Update the Dockfile using `ubuntu:20.04` and update rocksdb version from `v6.1.2` to `v6.20.3`.
2. Build docker and push as quarkchaindocker/goquarkchain:test1.6.1
3. Update actions/checkout using v4 and using docker quarkchaindocker/goquarkchain:test1.6.1 to fix action failure.





