### PR TITLE
Update checkdb actions: download quarkchain snapshot from storage box instead of S3

### DIFF
--- a/.github/workflows/checkdb.yml
+++ b/.github/workflows/checkdb.yml
@@ -46,6 +46,6 @@ jobs:
                 echo "Sunday:checkdb until 0 "
                 ./cluster --cluster_config ../../mainnet/singularity/cluster_config_template.json --check_db
           else
-                echo "Not Sunday:checkdb 10w blocks"
+                echo "Not Sunday:checkdb 100k blocks"
                 ./cluster --cluster_config ../../mainnet/singularity/cluster_config_template.json --check_db --check_db_rblock_to=-100000
           fi

--- a/.github/workflows/checkdb.yml
+++ b/.github/workflows/checkdb.yml
@@ -5,20 +5,24 @@ on:
 jobs:
   download-snapshot-and-checkdb:
     runs-on: self-hosted
-    container: quarkchaindocker/goquarkchain
+    container: quarkchaindocker/goquarkchain:test1.6.1
     timeout-minutes: 2880
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install Dependencies and Build
         run: |
           echo "Install Dependencies and Build"
+          apt update && apt upgrade -y && apt install sshpass
+
       - name: Download DB snapshot
         run: |
           cd cmd/cluster
           mkdir  qkc-data
-          curl https://qkcmainnet-go.s3.amazonaws.com/data/`curl https://qkcmainnet-go.s3.amazonaws.com/data/LATEST`.tar.gz --output data.tar.gz
+          sshpass -p ${{ secrets.SBOX_SA_PASSWORD }} scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null u446960-sub2@u446960-sub2.your-storagebox.de:VERSION-GO VERSION-GO
+          fileName=`cat VERSION-GO`
+          sshpass -p ${{ secrets.SBOX_SA_PASSWORD }} scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null u446960-sub2@u446960-sub2.your-storagebox.de:$fileName data.tar.gz
           tar xvfz data.tar.gz
           rm data.tar.gz && mv mainnet qkc-data
 
@@ -42,6 +46,6 @@ jobs:
                 echo "Sunday:checkdb until 0 "
                 ./cluster --cluster_config ../../mainnet/singularity/cluster_config_template.json --check_db
           else
-                echo "Not Sunday:checkdb until 40w"
-                ./cluster --cluster_config ../../mainnet/singularity/cluster_config_template.json --check_db --check_db_rblock_to=600000
+                echo "Not Sunday:checkdb 10w blocks"
+                ./cluster --cluster_config ../../mainnet/singularity/cluster_config_template.json --check_db --check_db_rblock_to=-100000
           fi

--- a/cluster/master/backend.go
+++ b/cluster/master/backend.go
@@ -183,10 +183,7 @@ func (s *QKCMasterBackend) CheckDB() {
 	// Start with root db
 	rb := s.rootBlockChain.CurrentBlock()
 	fromHeight := s.clusterConfig.CheckDBRBlockFrom
-	toHeight := uint64(s.clusterConfig.CheckDBRBlockTo)
-	if toHeight < 1 {
-		toHeight = 1
-	}
+
 	if fromHeight >= 0 && uint64(fromHeight) < rb.NumberU64() {
 		rb = s.rootBlockChain.GetBlockByNumber(uint64(fromHeight)).(*types.RootBlock)
 		log.Info("Starting from root block ", "height", fromHeight)
@@ -195,6 +192,17 @@ func (s *QKCMasterBackend) CheckDB() {
 		log.Error("Root block mismatches local root block by hash", "height", rb.NumberU64())
 		return
 	}
+
+	toHeight := uint64(1)
+	if s.clusterConfig.CheckDBRBlockTo > 0 {
+		toHeight = uint64(s.clusterConfig.CheckDBRBlockTo)
+	} else if s.clusterConfig.CheckDBRBlockTo < 0 {
+		reduceCount := uint64(-s.clusterConfig.CheckDBRBlockTo)
+		if reduceCount < rb.NumberU64() {
+			toHeight = rb.NumberU64() - reduceCount
+		}
+	}
+	log.Info("End root block ", "height", toHeight)
 
 	size := s.clusterConfig.CheckDBRBlockBatch
 	count := 0

--- a/tool/backup-go.sh
+++ b/tool/backup-go.sh
@@ -1,0 +1,22 @@
+sshpass -p $PriKey scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null u446960@u446960.your-storagebox.de:public-data/VERSION-GO VERSION-GO
+
+filename=`cat VERSION-GO`
+
+if [ $filename = "Archive-Go-A.tar.gz" ]; then
+  filename="Archive-Go-B.tar.gz"
+else
+  filename="Archive-Go-A.tar.gz"
+fi
+echo $filename
+
+
+rm $filename
+curl https://qkcmainnet-go.s3.amazonaws.com/data/`curl https://qkcmainnet-go.s3.amazonaws.com/data/LATEST`.tar.gz --output $filename
+
+sshpass -p $PriKey scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $filename u446960@u446960.your-storagebox.de:public-data/$filename
+
+echo $filename > VERSION-GO
+
+sshpass -p $PriKey scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null VERSION-GO u446960@u446960.your-storagebox.de:public-data/VERSION-GO
+
+rm $filename


### PR DESCRIPTION
Update checkdb actions: download quarkchain snapshot from storage box instead of S3.
Dependent PR: need to wait for https://github.com/QuarkChain/goquarkchain/pull/665 to check-in.

1. Using docker quarkchaindocker/pyquarkchain:test1.6.1
2. Download quarkchain snapshot from storage box instead of S3
3. Add archive script
4. Use dynamic `check_db_rblock_to`, if its `value` is smaller than _0_, then `check_db_rblock_to` set to latest hight - `value`.  

Note: 
Currently goquarkchain backup and upload snapshot to S3 on goquarkchain-mainnet (digitalocean) every two weeks. and the Archive script download snapshot from S3 and upload to storage box every two week (2 days after snapshot upload task start).

**How Archive Script Work**
As archive script download and replace the snapshot on storage box while the checkDB action is running, so storage box will keep 2 version of snapshot, adding a `VERSION-GO` file to recorde which is latest version and can be used by checkDB, and archive script will replace another one. the `VERSION-GO` file will be updated after latest version upload to storage box.

**Test action**: https://github.com/QuarkChain/goquarkchain/actions/runs/13585480498 



