### PR TITLE
update go version due to Go 'CVE-2020-28362' issue

### DIFF
--- a/.github/workflows/qkcli-test.yml
+++ b/.github/workflows/qkcli-test.yml
@@ -15,7 +15,7 @@ jobs:
           path: qkcli
       - uses: actions/setup-go@v5
         with:
-          go-version: "~1.14.4"
+          go-version: "~1.14.12"
       - run: go version
       - run: |
           cd qkcli && go build && go install && cd tester  && mv go_runner.sh runner.sh && bash parallel_executor.sh

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ If you prefer to use Docker, you can [run a cluster inside Docker container](#ru
 ###  Setup Go Environment
 Goquarkchain requires golang sdk >= 1.13. You can skip this step if your environment meets the condition.
 ```bash
-# take go1.14.1 for example:
-wget https://studygolang.com/dl/golang/go1.14.1.linux-amd64.tar.gz
-sudo tar xvzf go1.14.1.linux-amd64.tar.gz -C /usr/local
+# take go1.14.12 for example:
+wget https://studygolang.com/dl/golang/go1.14.12.linux-amd64.tar.gz
+sudo tar xvzf go1.14.12.linux-amd64.tar.gz -C /usr/local
 ```
 Append the following environment variables to ~/.profile. NOTE goproxy and go.mod are used.
 ```bash
@@ -46,7 +46,7 @@ source ~/.profile
 ```
 Check Go installation
 ```bash
-go version #go version go1.14.1 linux/amd64
+go version #go version go1.14.12 linux/amd64
 ```
 ### Setup RocksDB Environment
 Before install RocksDB, you'll need to install the following dependency packages.
@@ -306,8 +306,7 @@ However for CentOS specifically, you can try the following steps:
 A: We will support as many platforms as we can in the future, but currently only Ubuntu is fully tested, so it is recommended that you use Docker.  
 However for macOS specifically, you can try the following steps:
 
-First,you should download xcode through the app store 
-and then open  terminal  
+First, you should download xcode through the app store and then open terminal  
  ```bash
  #install brew:
          /usr/bin/ruby -e “$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)”

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ ENV LD_LIBRARY_PATH=/usr/local/lib
 
 # install golang
 WORKDIR /code
-RUN curl -sSL https://storage.googleapis.com/golang/go1.14.1.linux-amd64.tar.gz \
+RUN curl -sSL https://storage.googleapis.com/golang/go1.14.12.linux-amd64.tar.gz \
 		| tar -v -C /usr/local -xz
 ENV GOPATH $HOME/go
 ENV PATH $PATH:/usr/local/go/bin


### PR DESCRIPTION
[CVE-2020-28362](https://github.com/advisories/GHSA-gff4-9rfx-4pcw) is a high-severity vulnerability in Go’s math/big package that allows a Denial of Service (DoS) attack. It affects Go versions before 1.14.12 and 1.15.x before 1.15.4. The issue arises due to improper handling of large integers, which can be exploited to crash applications using math/big, particularly in cryptographic contexts such as certificate validation (
Such as crypto/rsa and crypto/x509). The vulnerability is associated with CWE-295 (Improper Certificate Validation) and has a CVSS v3.1 score of 7.5 (High).

For more details, visit the [NVD page](https://nvd.nist.gov/vuln/detail/CVE-2020-28362).

Ethereum related security issue: [Denial of service due to Go CVE-2020-28362](https://github.com/ethereum/go-ethereum/security/advisories/GHSA-m6gx-rhvj-fh52)

 