### PR TITLE
security update to fix 'DoS via malicious p2p message'

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -109,6 +109,7 @@ type Peer struct {
 	wg       sync.WaitGroup
 	protoErr chan error
 	closed   chan struct{}
+	pingRecv chan struct{}
 	disc     chan DiscReason
 
 	// events receives message send / receive events if set
@@ -185,6 +186,7 @@ func newPeer(conn *conn, protocols []Protocol) *Peer {
 		disc:     make(chan DiscReason),
 		protoErr: make(chan error, len(protomap)+1), // protocols + pingLoop
 		closed:   make(chan struct{}),
+		pingRecv: make(chan struct{}, 16),
 		log:      log.New("id", conn.node.ID(), "conn", conn.flags),
 	}
 	return p
@@ -244,9 +246,11 @@ loop:
 }
 
 func (p *Peer) pingLoop() {
-	ping := time.NewTimer(pingInterval)
 	defer p.wg.Done()
+
+	ping := time.NewTimer(pingInterval)
 	defer ping.Stop()
+
 	for {
 		select {
 		case <-ping.C:
@@ -255,6 +259,10 @@ func (p *Peer) pingLoop() {
 				return
 			}
 			ping.Reset(pingInterval)
+
+		case <-p.pingRecv:
+			SendItems(p.rw, pongMsg)
+
 		case <-p.closed:
 			return
 		}
@@ -281,7 +289,10 @@ func (p *Peer) handle(msg Msg) error {
 	switch {
 	case msg.Code == pingMsg:
 		msg.Discard()
-		go SendItems(p.rw, pongMsg)
+		select {
+		case p.pingRecv <- struct{}{}:
+		case <-p.closed:
+		}
 	case msg.Code == discMsg:
 		var reason [1]DiscReason
 		// This is the last message. We don't need to discard or

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -203,8 +203,9 @@ func (p *Peer) run() (remoteRequested bool, err error) {
 		readErr    = make(chan error, 1)
 		reason     DiscReason // sent to the peer
 	)
-	p.wg.Add(1)
+	p.wg.Add(2)
 	go p.readLoop(readErr)
+	go p.pingLoop()
 
 	// Start all protocol handlers.
 	writeStart <- struct{}{}

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -520,11 +520,25 @@ func importPublicKey(pubKey []byte) (*ecies.PublicKey, error) {
 		return nil, fmt.Errorf("invalid public key length %v (expect 64/65)", len(pubKey))
 	}
 	// TODO: fewer pointless conversions
+	if !isOnCurve(pubKey65) {
+		return nil, errors.New("invalid secp256k1 public key")
+	}
 	pub, err := crypto.UnmarshalPubkey(pubKey65)
 	if err != nil {
 		return nil, err
 	}
 	return ecies.ImportECDSAPublic(pub), nil
+}
+
+func isOnCurve(pubKey65 []byte) bool {
+	x, y := elliptic.Unmarshal(crypto.S256(), pubKey65)
+	if x == nil {
+		return false
+	}
+	if !crypto.S256().IsOnCurve(x, y) {
+		return false
+	}
+	return true
 }
 
 func exportPubkey(pub *ecies.PublicKey) []byte {

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -520,25 +520,11 @@ func importPublicKey(pubKey []byte) (*ecies.PublicKey, error) {
 		return nil, fmt.Errorf("invalid public key length %v (expect 64/65)", len(pubKey))
 	}
 	// TODO: fewer pointless conversions
-	if !isOnCurve(pubKey65) {
-		return nil, errors.New("invalid secp256k1 public key")
-	}
 	pub, err := crypto.UnmarshalPubkey(pubKey65)
 	if err != nil {
 		return nil, err
 	}
 	return ecies.ImportECDSAPublic(pub), nil
-}
-
-func isOnCurve(pubKey65 []byte) bool {
-	x, y := elliptic.Unmarshal(crypto.S256(), pubKey65)
-	if x == nil {
-		return false
-	}
-	if !crypto.S256().IsOnCurve(x, y) {
-		return false
-	}
-	return true
 }
 
 func exportPubkey(pub *ecies.PublicKey) []byte {


### PR DESCRIPTION
**Security issue**
[DoS via malicious p2p message](https://github.com/ethereum/go-ethereum/security/advisories/GHSA-ppjg-v974-84cm)

**Impact**
A vulnerable node, can be made to consume unbounded amounts of memory when handling specially crafted p2p messages sent from an attacker node.

**Details**
The p2p handler spawned a new goroutine to respond to ping requests. By flooding a node with ping requests, an unbounded number of goroutines can be created, leading to resource exhaustion and potentially crash due to OOM.

**Ethereum Patches** 
Fixed by https://github.com/ethereum/go-ethereum/pull/27887
