### PR TITLE
Update qkcmainnet-go to goqkcmainnet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,4 +183,4 @@ jobs:
       - name: Deploy static site to S3 bucket
         run: |
           sudo apt-get update && sudo apt-get install awscli -y
-          aws s3 sync release/ s3://goqkcmainnet/data/release --acl public-read
+          aws s3 sync release/ s3://goqkcmainnet/data/release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,4 +183,4 @@ jobs:
       - name: Deploy static site to S3 bucket
         run: |
           sudo apt-get update && sudo apt-get install awscli -y
-          aws s3 sync release/ s3://qkcmainnet-go/data/release --acl public-read
+          aws s3 sync release/ s3://goqkcmainnet/data/release --acl public-read

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,9 +18,9 @@ $ sudo docker run -v /path/to/data:/go/src/github.com/QuarkChain/goquarkchain/cm
 # every 24 hours a snapshot of the database will be taken and uploaded by the QuarkChain team.
 # once you start your cluster using the downloaded database your cluster only need to sync
 # the blocks mined in the past 24 hours or less.
-curl https://qkcmainnet-go.s3.amazonaws.com/data/`curl https://qkcmainnet-go.s3.amazonaws.com/data/LATEST`.tar.gz --output data.tar.gz
+curl https://goqkcmainnet.s3.amazonaws.com/data/`curl https://goqkcmainnet.s3.amazonaws.com/data/LATEST`.tar.gz --output data.tar.gz
 # if use rocksdb 
-# curl https://qkcmainnet-go.s3.amazonaws.com/data/qkc_rocksdb.tar.gz --output data.tar.gz (not suggest,not update,rootBlock's height:59w)
+# curl https://goqkcmainnet.s3.amazonaws.com/data/qkc_rocksdb.tar.gz --output data.tar.gz (not suggest,not update,rootBlock's height:59w)
 # then should unzip to the right path
 
 # INSIDE the container

--- a/mainnet/snapshot/backup.sh
+++ b/mainnet/snapshot/backup.sh
@@ -33,5 +33,5 @@ cd -
 echo $DATE > $LATEST_FILE
 
 # this  need aws s3 'Access key ID' and 'Private access key',and that key must have permission to s3
-aws s3 sync $BACKUP_DIR s3://qkcmainnet-go/data --acl public-read
+aws s3 sync $BACKUP_DIR s3://goqkcmainnet/data
 

--- a/tool/backup-go.sh
+++ b/tool/backup-go.sh
@@ -11,7 +11,7 @@ echo $filename
 
 
 rm $filename
-curl https://qkcmainnet-go.s3.amazonaws.com/data/`curl https://qkcmainnet-go.s3.amazonaws.com/data/LATEST`.tar.gz --output $filename
+curl https://goqkcmainnet.s3.amazonaws.com/data/`curl https://goqkcmainnet.s3.amazonaws.com/data/LATEST`.tar.gz --output $filename
 
 sshpass -p $PriKey scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $filename u446960@u446960.your-storagebox.de:public-data/$filename
 


### PR DESCRIPTION
As we are moving S3 to aws account, we set up goqkcmainnet to replace qkcmainnet-go. 
As the new S3 buket already setup to public read, no need to add `--acl public-read` when upload