### PR TITLE
Fix unit tests in algorithm_test.go

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: daily-test
         run: |          
+          export GOPROXY=https://proxy.golang.org
           cd consensus/qkchash/native && make && cd -
           go vet ./...
           go test -timeout 1m ./... -gcflags=-l

--- a/consensus/qkchash/algorithm_test.go
+++ b/consensus/qkchash/algorithm_test.go
@@ -1,4 +1,5 @@
-//+build !nt
+//go:build !nt
+// +build !nt
 
 package qkchash
 
@@ -102,7 +103,7 @@ func BenchmarkQKCHashX(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		seed := make([]byte, 40)
-		copy(seed, []byte("HELLO"))
+		copy(seed, []byte("HELLOW"))
 		_, _, err = qkcHashX(seed, cache, false)
 	}
 	benchErr = err
@@ -114,7 +115,7 @@ func BenchmarkQKCHashX_UseX(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		seed := make([]byte, 40)
-		copy(seed, []byte("HELLO"))
+		copy(seed, []byte("HELLOW"))
 		_, _, err = qkcHashX(seed, cache, true)
 	}
 	benchErr = err
@@ -125,7 +126,7 @@ func TestQKCHashXResult(t *testing.T) {
 	result := []byte{45, 160, 166, 176, 163, 16, 103, 190, 69, 209, 193, 89, 157, 138, 89, 214, 43, 240, 248, 189, 88, 12, 148, 15, 176, 31, 157, 136, 126, 110, 98, 1}
 	cache := generateCache(cacheEntryCnt, nil)
 	seed := make([]byte, 40)
-	copy(seed, []byte("HELLO"))
+	copy(seed, []byte("HELLOW"))
 	digestX, resultX, err := qkcHashX(seed, cache, false)
 	assert.NoError(t, err)
 	assert.Equal(t, digest, digestX)
@@ -137,7 +138,7 @@ func TestQKCHashXResult_UseX(t *testing.T) {
 	result := []byte{227, 252, 40, 42, 175, 149, 150, 225, 16, 184, 64, 85, 21, 230, 53, 127, 165, 81, 200, 158, 57, 125, 34, 242, 21, 29, 114, 7, 38, 40, 215, 202}
 	cache := generateCache(cacheEntryCnt, nil)
 	seed := make([]byte, 40)
-	copy(seed, []byte("HELLO"))
+	copy(seed, []byte("HELLOW"))
 	digestX, resultX, err := qkcHashX(seed, cache, true)
 	assert.NoError(t, err)
 	assert.Equal(t, digest, digestX)


### PR DESCRIPTION
Fix the following test errors introduced by [this pr](https://github.com/QuarkChain/goquarkchain/pull/664/changes#diff-f53a758f995c04ae83c3d562025438f561b20c68f39c865e86e6fc8c90179bbbL105):
```
--- FAIL: TestQKCHashXResult (0.08s)
    algorithm_test.go:131: 
        	Error Trace:	algorithm_test.go:131
        	Error:      	Not equal: 
        	            	expected: []byte{0x89, 0xf2, 0xed, 0x15, 0x3a, 0x82, 0xc4, 0x97, 0xa, 0x80, 0x25, 0x54, 0x5a, 0x39, 0x1b, 0x85, 0x25, 0xef, 0x32, 0x48, 0x4a, 0xf5, 0x91, 0x86, 0xd2, 0x5e, 0x1e, 0x37, 0xcd, 0xf7, 0xf8, 0x18}
        	            	actual  : []byte{0x10, 0x21, 0xa8, 0x26, 0x16, 0x60, 0x78, 0xcf, 0x10, 0xb4, 0x2f, 0xde, 0x9e, 0x29, 0x93, 0x36, 0x47, 0x43, 0x6, 0x91, 0x79, 0x8b, 0x13, 0x5a, 0x25, 0x62, 0x5b, 0x0, 0xf4, 0x6d, 0x5f, 0xa1}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,4 +1,4 @@
        	            	 ([]uint8) (len=32) {
        	            	- 00000000  89 f2 ed 15 3a 82 c4 97  0a 80 25 54 5a 39 1b 85  |....:.....%TZ9..|
        	            	- 00000010  25 ef 32 48 4a f5 91 86  d2 5e 1e 37 cd f7 f8 18  |%.2HJ....^.7....|
        	            	+ 00000000  10 21 a8 26 16 60 78 cf  10 b4 2f de 9e 29 93 36  |.!.&.`x.../..).6|
        	            	+ 00000010  47 43 06 91 79 8b 13 5a  25 62 5b 00 f4 6d 5f a1  |GC..y..Z%b[..m_.|
        	            	 }
        	Test:       	TestQKCHashXResult
    algorithm_test.go:132: 
        	Error Trace:	algorithm_test.go:132
        	Error:      	Not equal: 
        	            	expected: []byte{0x2d, 0xa0, 0xa6, 0xb0, 0xa3, 0x10, 0x67, 0xbe, 0x45, 0xd1, 0xc1, 0x59, 0x9d, 0x8a, 0x59, 0xd6, 0x2b, 0xf0, 0xf8, 0xbd, 0x58, 0xc, 0x94, 0xf, 0xb0, 0x1f, 0x9d, 0x88, 0x7e, 0x6e, 0x62, 0x1}
        	            	actual  : []byte{0x6d, 0xe8, 0xf7, 0x7, 0x6a, 0xb4, 0x48, 0xc7, 0xaa, 0xae, 0x7, 0xf9, 0x53, 0x33, 0x3b, 0x55, 0xcb, 0x51, 0x88, 0x8b, 0x47, 0xd7, 0xed, 0xaa, 0x8a, 0x51, 0x2b, 0x87, 0x42, 0x30, 0xe9, 0xd7}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,4 +1,4 @@
        	            	 ([]uint8) (len=32) {
        	            	- 00000000  2d a0 a6 b0 a3 10 67 be  45 d1 c1 59 9d 8a 59 d6  |-.....g.E..Y..Y.|
        	            	- 00000010  2b f0 f8 bd 58 0c 94 0f  b0 1f 9d 88 7e 6e 62 01  |+...X.......~nb.|
        	            	+ 00000000  6d e8 f7 07 6a b4 48 c7  aa ae 07 f9 53 33 3b 55  |m...j.H.....S3;U|
        	            	+ 00000010  cb 51 88 8b 47 d7 ed aa  8a 51 2b 87 42 30 e9 d7  |.Q..G....Q+.B0..|
        	            	 }
        	Test:       	TestQKCHashXResult
--- FAIL: TestQKCHashXResult_UseX (0.08s)
    algorithm_test.go:143: 
        	Error Trace:	algorithm_test.go:143
        	Error:      	Not equal: 
        	            	expected: []byte{0xef, 0xa5, 0x0, 0x67, 0x8f, 0xf8, 0xe3, 0x31, 0xec, 0x98, 0xa8, 0xec, 0x3b, 0x3b, 0x76, 0x3f, 0xc5, 0x44, 0x32, 0x30, 0x39, 0xf1, 0xe1, 0x93, 0x26, 0xb1, 0x3f, 0xdd, 0x73, 0xae, 0xd8, 0xb1}
        	            	actual  : []byte{0x60, 0x1a, 0x67, 0x8b, 0x39, 0x4, 0x2e, 0x81, 0x23, 0xed, 0x63, 0x6f, 0xfe, 0x85, 0xe9, 0xa2, 0xf3, 0xdf, 0x4b, 0x3b, 0xc, 0x31, 0xb5, 0xf8, 0xc1, 0x1f, 0x74, 0xc8, 0x96, 0x26, 0x7c, 0x13}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,4 +1,4 @@
        	            	 ([]uint8) (len=32) {
        	            	- 00000000  ef a5 00 67 8f f8 e3 31  ec 98 a8 ec 3b 3b 76 3f  |...g...1....;;v?|
        	            	- 00000010  c5 44 32 30 39 f1 e1 93  26 b1 3f dd 73 ae d8 b1  |.D209...&.?.s...|
        	            	+ 00000000  60 1a 67 8b 39 04 2e 81  23 ed 63 6f fe 85 e9 a2  |`.g.9...#.co....|
        	            	+ 00000010  f3 df 4b 3b 0c 31 b5 f8  c1 1f 74 c8 96 26 7c 13  |..K;.1....t..&|.|
        	            	 }
        	Test:       	TestQKCHashXResult_UseX
    algorithm_test.go:144: 
        	Error Trace:	algorithm_test.go:144
        	Error:      	Not equal: 
        	            	expected: []byte{0xe3, 0xfc, 0x28, 0x2a, 0xaf, 0x95, 0x96, 0xe1, 0x10, 0xb8, 0x40, 0x55, 0x15, 0xe6, 0x35, 0x7f, 0xa5, 0x51, 0xc8, 0x9e, 0x39, 0x7d, 0x22, 0xf2, 0x15, 0x1d, 0x72, 0x7, 0x26, 0x28, 0xd7, 0xca}
        	            	actual  : []byte{0x6b, 0xcf, 0x79, 0x6d, 0x58, 0xb, 0xa6, 0x59, 0x43, 0x9f, 0xa4, 0x4c, 0x1c, 0xb7, 0xe7, 0x59, 0xad, 0x6, 0xe, 0xee, 0x37, 0xad, 0x3a, 0x31, 0x66, 0xe7, 0x5c, 0xd9, 0x1, 0xd2, 0x2d, 0xa4}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,4 +1,4 @@
        	            	 ([]uint8) (len=32) {
        	            	- 00000000  e3 fc 28 2a af 95 96 e1  10 b8 40 55 15 e6 35 7f  |..(*......@U..5.|
        	            	- 00000010  a5 51 c8 9e 39 7d 22 f2  15 1d 72 07 26 28 d7 ca  |.Q..9}"...r.&(..|
        	            	+ 00000000  6b cf 79 6d 58 0b a6 59  43 9f a4 4c 1c b7 e7 59  |k.ymX..YC..L...Y|
        	            	+ 00000010  ad 06 0e ee 37 ad 3a 31  66 e7 5c d9 01 d2 2d a4  |....7.:1f.\...-.|
        	            	 }
        	Test:       	TestQKCHashXResult_UseX
```