### PR TITLE
QuarkChain RPC health check workflow - add fullnode3

### DIFF
--- a/.github/workflows/rpc_healthcheck.yml
+++ b/.github/workflows/rpc_healthcheck.yml
@@ -34,6 +34,9 @@ jobs:
           - network: devnetHost
             rpc_url: http://50.112.62.65:38391
             expected_network_id: "0xff"
+          - network: mainnetHost-fullnode3
+            rpc_url: http://164.92.84.144:38391
+            expected_network_id: "0x1"
 
     steps:
       - name: Check endpoint JSON field


### PR DESCRIPTION
The QuarkChain fullnode3 on DigitalOcean (164.92.84.144) occasionally stops—most likely due to a memory explosion. 

Add it to the RPC health check workflow.