### PR TITLE
fix(Bug4): guard `isSameRootChain` against `log.Crit` crash when long < short

### DIFF
--- a/core/minorblockchain_addon.go
+++ b/core/minorblockchain_addon.go
@@ -377,6 +377,9 @@ func (m *MinorBlockChain) GetTransactionCount(recipient account.Recipient, hash 
 }
 
 func (m *MinorBlockChain) isSameRootChain(long types.IBlock, short types.IBlock) bool {
+	if long.NumberU64() < short.NumberU64() {
+		return false
+	}
 	f := func(hash common.Hash) common.Hash {
 		if b := m.GetRootBlockByHash(hash); b == nil {
 			return common.Hash{}

--- a/core/minorblockchain_addon.go
+++ b/core/minorblockchain_addon.go
@@ -1079,7 +1079,14 @@ func (m *MinorBlockChain) AddRootBlock(rBlock *types.RootBlock) (bool, error) {
 		return false, nil
 	}
 
+	// Hold m.mu for the entire root/minor head transition to prevent CreateBlockToMine
+	// from reading an inconsistent snapshot (new rootTip with stale currentBlock).
+	// Previously, the lock was released after updating rootTip but before rewinding
+	// currentBlock, allowing mining to observe the intermediate state and call
+	// isSameRootChain with mismatched heights.
 	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	m.rootTip = rBlock
 	if shardHeader == nil {
 		m.confirmedHeaderTip = nil
@@ -1087,7 +1094,6 @@ func (m *MinorBlockChain) AddRootBlock(rBlock *types.RootBlock) (bool, error) {
 		m.confirmedHeaderTip = m.GetMinorBlock(shardHeader.Hash())
 	}
 
-	m.mu.Unlock()
 	origHeaderTip := m.CurrentBlock()
 	if shardHeader != nil {
 		origBlock := m.GetBlockByNumber(shardHeader.Number)

--- a/core/minorblockchain_addon.go
+++ b/core/minorblockchain_addon.go
@@ -1079,14 +1079,7 @@ func (m *MinorBlockChain) AddRootBlock(rBlock *types.RootBlock) (bool, error) {
 		return false, nil
 	}
 
-	// Hold m.mu for the entire root/minor head transition to prevent CreateBlockToMine
-	// from reading an inconsistent snapshot (new rootTip with stale currentBlock).
-	// Previously, the lock was released after updating rootTip but before rewinding
-	// currentBlock, allowing mining to observe the intermediate state and call
-	// isSameRootChain with mismatched heights.
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	m.rootTip = rBlock
 	if shardHeader == nil {
 		m.confirmedHeaderTip = nil
@@ -1094,6 +1087,7 @@ func (m *MinorBlockChain) AddRootBlock(rBlock *types.RootBlock) (bool, error) {
 		m.confirmedHeaderTip = m.GetMinorBlock(shardHeader.Hash())
 	}
 
+	m.mu.Unlock()
 	origHeaderTip := m.CurrentBlock()
 	if shardHeader != nil {
 		origBlock := m.GetBlockByNumber(shardHeader.Number)

--- a/core/shardstate_test.go
+++ b/core/shardstate_test.go
@@ -3637,3 +3637,35 @@ func TestXshardGasLimitFromMultipleShards(t *testing.T) {
 	tb = shardState0.currentEvmState.GetBalance(acc1.Recipient, shardState0.GetGenesisToken())
 	assert.Equal(t, tb, big.NewInt(10000000+1000000+12345+888888+111111))
 }
+
+// TestIsSameRootChainInvertedArgs verifies that isSameRootChain returns false when
+// the first argument (long) has a lower block number than the second (short).
+//
+// isSameChain assumes long.Number >= short.Number and calls log.Crit otherwise,
+// which terminates the process. The guard in isSameRootChain must intercept this
+// before reaching isSameChain.
+//
+// Trigger in production: reRunBlockWithState calls
+// isSameRootChain(m.rootTip, ancestorRootHeader) where ancestorRootHeader.Number >
+// m.rootTip.Number during startup or after a root chain rewind.
+func TestIsSameRootChainInvertedArgs(t *testing.T) {
+	env := setUp(nil, nil, nil)
+	shardState := createDefaultShardState(env, nil, nil, nil, nil)
+	defer shardState.Stop()
+
+	// Build two root blocks: rb1 (height 1) and rb2 (height 2).
+	rb1 := shardState.rootTip.Header().CreateBlockToAppend(nil, nil, nil, nil, nil).Finalize(nil, nil, common.Hash{})
+	rb2 := rb1.Header().CreateBlockToAppend(nil, nil, nil, nil, nil).Finalize(nil, nil, common.Hash{})
+
+	// Correct order: long=rb2 (height 2), short=rb1 (height 1).
+	// rb2 was not added to DB so the chains differ, but the call must not crash.
+	_ = shardState.isSameRootChain(rb2, rb1)
+
+	// Inverted order: long=rb1 (height 1) < short=rb2 (height 2).
+	// Without the guard this calls isSameChain which calls log.Crit → process exit.
+	// With the guard it must return false cleanly.
+	result := shardState.isSameRootChain(rb1, rb2)
+	if result != false {
+		t.Fatal("expected isSameRootChain to return false when long.Number < short.Number")
+	}
+}

--- a/core/shardstate_test.go
+++ b/core/shardstate_test.go
@@ -3658,8 +3658,10 @@ func TestIsSameRootChainInvertedArgs(t *testing.T) {
 	rb2 := rb1.Header().CreateBlockToAppend(nil, nil, nil, nil, nil).Finalize(nil, nil, common.Hash{})
 
 	// Correct order: long=rb2 (height 2), short=rb1 (height 1).
-	// rb2 was not added to DB so the chains differ, but the call must not crash.
-	_ = shardState.isSameRootChain(rb2, rb1)
+	// diff==1 so isSameChain compares rb2.ParentHash()==rb1.Hash() in-memory (no DB lookup).
+	if !shardState.isSameRootChain(rb2, rb1) {
+		t.Fatal("expected isSameRootChain to return true when rb2 is a direct child of rb1")
+	}
 
 	// Inverted order: long=rb1 (height 1) < short=rb2 (height 2).
 	// Without the guard this calls isSameChain which calls log.Crit → process exit.


### PR DESCRIPTION
  ### Problem

  `isSameChain` (the internal helper called by `isSameRootChain`) assumes its first argument (`long`) always has a block number ≥ the second argument (`short`). When that invariant is violated it calls `log.Crit`, which terminates the process.

  `isSameRootChain` is called as:
 ` isSameRootChain(m.rootTip, ancestorRootHeader)`

  During startup or after a root chain rewind, a minor block's `PrevRootBlockHash` can point to a root block taller than the current `m.rootTip`. This makes `long.Number < short.Number`, violating the invariant and causing a crash instead of a graceful false return.

 ### Fix

  Add a guard at the top of `isSameRootChain` (`core/minorblockchain_addon.go`):
```
  if long.NumberU64() < short.NumberU64() {
      return false
  }
```
  This short-circuits before reaching `isSameChain` and returns false cleanly, matching the semantically correct answer (a shorter chain cannot contain the longer one).

###  Test

  TestIsSameRootChainInvertedArgs (core/shardstate_test.go) covers two cases:
 | Case           | long           | short          | Expected             |
  |----------------|----------------|----------------|----------------------|
  | Normal order   | rb2 (height 2) | rb1 (height 1) | true (direct parent) |
  | Inverted order | rb1 (height 1) | rb2 (height 2) | false (no crash)     |

  Without the guard the inverted-order call hits `log.Crit` and exits the process. With the guard it returns false.
