### PR TITLE
fix(Bug5): HasBlock requires block body in addition to commit marker

### DIFF
--- a/cluster/shard/shard.go
+++ b/cluster/shard/shard.go
@@ -207,18 +207,12 @@ func (s *ShardBackend) initGenesisState(rootBlock *types.RootBlock) error {
 }
 
 func (s *ShardBackend) getBlockCommitStatusByHash(blockHash common.Hash) BlockCommitCode {
-	// If the block is committed, it means
-	// - All neighbor shards/slaves receives x-shard tx list
-	// - The block header is sent to master
-	// then return immediately
-	if s.MinorBlockChain.IsMinorBlockCommittedByHash(blockHash) {
+	// Require both the commit marker and the block body. A crash can leave the
+	// marker present but the body absent; in that case the block must be
+	// re-inserted so the body is restored.
+	if s.MinorBlockChain.HasBlock(blockHash) {
 		return BLOCK_COMMITTED
 	}
-
-	//TODO support BLOCK_COMMITTING???
-
-	// Check if the block is being propagating to other slaves and the master
-	// Let's make sure all the shards and master got it before committing it
 	return BLOCK_UNCOMMITTED
 }
 

--- a/core/minorblockchain.go
+++ b/core/minorblockchain.go
@@ -537,8 +537,11 @@ func (m *MinorBlockChain) Genesis() *types.MinorBlock {
 }
 
 // HasBlock checks if a block is fully present in the database or not.
+// Both the commit marker and the block body must exist. A crash (OOM/kill)
+// can leave the marker present while the body is absent; returning true in
+// that case causes sync to skip re-downloading the block and stall.
 func (m *MinorBlockChain) HasBlock(hash common.Hash) bool {
-	return m.IsMinorBlockCommittedByHash(hash)
+	return m.IsMinorBlockCommittedByHash(hash) && rawdb.HasBlock(m.db, hash)
 }
 
 // HasState checks if state trie is fully present in the database or not.

--- a/core/minorblockchain_test.go
+++ b/core/minorblockchain_test.go
@@ -1363,5 +1363,46 @@ func TestMinorLargeReorgTrieGC(t *testing.T) {
 	}
 }
 
+// TestHasBlockMarkerWithoutBodyReturnsFalse verifies that HasBlock returns false
+// when the commit marker is present but the block body is absent — the state left
+// after an OOM/kill crash where LevelDB flushed the marker but not the body.
+//
+// Before the fix HasBlock only checked IsMinorBlockCommittedByHash (marker-only),
+// so it returned true. Sync then skipped re-downloading the block and the next
+// block failed with "unknown ancestor" permanently.
+func TestHasBlockMarkerWithoutBodyReturnsFalse(t *testing.T) {
+	_, blockchain, err := newMinorCanonical(nil, engine, 3, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer blockchain.Stop()
+
+	block4 := makeBlockChain(blockchain.CurrentBlock(), 1, engine, blockchain.db, 77)[0]
+	if _, err := blockchain.InsertChain(toMinorBlocks([]*types.MinorBlock{block4}), false); err != nil {
+		t.Fatal(err)
+	}
+	h := block4.Hash()
+
+	if !blockchain.HasBlock(h) {
+		t.Fatal("HasBlock should be true after InsertChain")
+	}
+
+	// Simulate crash: body gone from rawdb, commit marker survives.
+	rawdb.DeleteBlock(blockchain.db, h)
+	blockchain.blockCache.Purge() // evict so GetMinorBlock re-reads from rawdb
+
+	if rawdb.HasBlock(blockchain.db, h) {
+		t.Fatal("body should be absent after DeleteBlock")
+	}
+	if !rawdb.HasCommitMinorBlock(blockchain.db, h) {
+		t.Fatal("commit marker should still be present")
+	}
+
+	// HasBlock must return false: marker alone is not enough.
+	if blockchain.HasBlock(h) {
+		t.Fatal("HasBlock returned true with marker present but body absent")
+	}
+}
+
 //TODO
 //Bench test: qkc genesis not support code set


### PR DESCRIPTION
### Problem

  HasBlock() previously only checked IsMinorBlockCommittedByHash() — the commit marker written to RocksDB at the end of InsertChain. After an kill or forced termination, RocksDB could flush the commit marker to disk while the block body may be deleted.

  On the next startup:
  - HasBlock(hash) returned true (marker present)
  - Sync assumed the block was already stored and skipped re-downloading it
  - The next block then failed with "unknown ancestor" or crash permanently, stalling the node

###  Root Cause

```
  // Before: marker-only check — blind to missing body
  func (m *MinorBlockChain) HasBlock(hash common.Hash) bool {
      return m.IsMinorBlockCommittedByHash(hash)
  }
```

###  Fix

  Require both the commit marker and the block body to exist:

```
  func (m *MinorBlockChain) HasBlock(hash common.Hash) bool {
      return m.IsMinorBlockCommittedByHash(hash) && rawdb.HasBlock(m.db, hash)
  }
```

  This mirrors the contract expected by the sync layer: a block is only "fully present" when its body can actually be retrieved.

###  Test
```
  go test ./...
```