### PR TITLE
chore: harden curl retry and timeout configuration in RPC healthcheck

### DIFF
--- a/.github/workflows/rpc_healthcheck.yml
+++ b/.github/workflows/rpc_healthcheck.yml
@@ -44,9 +44,16 @@ jobs:
           since_last_block=0
 
           code="$(
+            # Capture status code; use retries/timeouts to reduce flakiness.
+            # --retry / --retry-delay: retry on failure with backoff
+            # --retry-all-errors: retry on any error, not just transient ones
+            # --connect-timeout: time to wait for TCP connection / DNS
+            # --max-time: max total time per individual attempt
+            # --retry-max-time: cap on total time spent across all retries
             curl --silent --show-error --location \
-              --retry 3 --retry-delay 5 --retry-all-errors \
-              --connect-timeout 10 --max-time 30 \
+              --retry 10 --retry-delay 10 --retry-all-errors \
+              --connect-timeout 30 --max-time 120 \
+              --retry-max-time 600 \
               -X POST \
               -H 'Content-Type: application/json' \
               --data "$payload" \


### PR DESCRIPTION
## Summary

Harden curl command in RPC healthcheck workflow to improve reliability when dealing with network instability or slow RPC endpoints.

## Changes

Based on similar improvements from [ethstorage/es-node#516](https://github.com/ethstorage/es-node/pull/516), this PR enhances the curl command's resilience:

- Increase retry count from 3 to 10 with exponential backoff
- Increase connect timeout from 10s to 30s (more time for DNS/TCP connection)
- Increase max time per attempt from 30s to 120s (more time for response)
- Add `--retry-max-time 600` to cap total time across all retries (10 minutes)
- Add detailed comments explaining each curl option for maintainability

## Testing

https://github.com/QuarkChain/goquarkchain/actions/runs/27323687431