### PR TITLE
fix: replace setHead with RollbackToBlock and fix same-chain reorg

### DIFF
--- a/cluster/shard/api_backend.go
+++ b/cluster/shard/api_backend.go
@@ -378,12 +378,18 @@ func (s *ShardBackend) AddMinorBlock(block *types.MinorBlock) error {
 
 	prevRootHeight := s.MinorBlockChain.GetRootBlockByHash(block.PrevRootBlockHash()).Number()
 	if err := s.conn.BroadcastXshardTxList(block, xshardLst[0], prevRootHeight); err != nil {
-		s.setHead(currHead.Number)
+		log.Warn(s.logInfo+" BroadcastXshardTxList failed, rolling back to prev head", "number", block.NumberU64(), "err", err)
+		if rbErr := s.MinorBlockChain.RollbackToBlock(currHead.Hash()); rbErr != nil {
+			log.Error(s.logInfo, "Failed to rollback after BroadcastXshardTxList error", "err", rbErr)
+		}
 		return err
 	}
 	status, err := s.MinorBlockChain.GetShardStats()
 	if err != nil {
-		s.setHead(currHead.Number)
+		log.Warn(s.logInfo+" GetShardStats failed, rolling back to prev head", "number", block.NumberU64(), "err", err)
+		if rbErr := s.MinorBlockChain.RollbackToBlock(currHead.Hash()); rbErr != nil {
+			log.Error(s.logInfo, "Failed to rollback after GetShardStats error", "err", rbErr)
+		}
 		return err
 	}
 
@@ -396,18 +402,19 @@ func (s *ShardBackend) AddMinorBlock(block *types.MinorBlock) error {
 	}
 	err = s.conn.SendMinorBlockHeaderToMaster(requests)
 	if err != nil {
-		s.setHead(currHead.Number)
+		log.Warn(s.logInfo+" SendMinorBlockToMaster failed, rolling back to prev head", "number", block.NumberU64(), "err", err)
+		if rbErr := s.MinorBlockChain.RollbackToBlock(currHead.Hash()); rbErr != nil {
+			log.Error(s.logInfo, "Failed to rollback after SendMinorBlockToMaster error", "err", rbErr)
+		}
 		return err
 	}
-	s.MinorBlockChain.CommitMinorBlockByHash(block.Hash())
 	if s.MinorBlockChain.CurrentBlock().Hash() != currHead.Hash() {
 		go s.miner.HandleNewTip()
 	}
 	// block has been added to local state, broadcast tip so that peers can sync if needed
 	if currHead.Hash() != s.MinorBlockChain.CurrentBlock().Hash() {
 		if err = s.broadcastNewTip(); err != nil {
-			s.setHead(currHead.Number)
-			return err
+			log.Warn(s.logInfo+" broadcastNewTip failed, peers will sync later", "number", block.NumberU64(), "err", err)
 		}
 	}
 
@@ -430,6 +437,7 @@ func (s *ShardBackend) AddBlockListForSync(blockLst []*types.MinorBlock) error {
 		return nil
 	}
 
+	prevHead := s.MinorBlockChain.CurrentBlock()
 	var (
 		blockHashToXShardList      = make(map[common.Hash]*XshardListTuple)
 		uncommittedBlockHeaderList = make([]*types.MinorBlockHeader, 0, len(blockLst))
@@ -457,8 +465,11 @@ func (s *ShardBackend) AddBlockListForSync(blockLst []*types.MinorBlock) error {
 		blockHashToXShardList[blockHash] = &XshardListTuple{XshardTxList: xshardLst[0], PrevRootHeight: prevRootHeight.Number()}
 		uncommittedBlockHeaderList = append(uncommittedBlockHeaderList, block.Header())
 	}
-	// interrupt the current miner and restart
 	if err := s.conn.BatchBroadcastXshardTxList(blockHashToXShardList, blockLst[0].Branch()); err != nil {
+		log.Warn(s.logInfo+" BatchBroadcastXshardTxList failed, rolling back", "err", err)
+		if rbErr := s.MinorBlockChain.RollbackToBlock(prevHead.Hash()); rbErr != nil {
+			log.Error(s.logInfo, "Failed to rollback AddBlockListForSync", "err", rbErr)
+		}
 		return err
 	}
 
@@ -466,6 +477,10 @@ func (s *ShardBackend) AddBlockListForSync(blockLst []*types.MinorBlock) error {
 		MinorBlockHeaderList: uncommittedBlockHeaderList,
 	}
 	if err := s.conn.SendMinorBlockHeaderListToMaster(req); err != nil {
+		log.Warn(s.logInfo+" SendMinorBlockHeaderListToMaster failed, rolling back", "err", err)
+		if rbErr := s.MinorBlockChain.RollbackToBlock(prevHead.Hash()); rbErr != nil {
+			log.Error(s.logInfo, "Failed to rollback AddBlockListForSync", "err", rbErr)
+		}
 		return err
 	}
 	for _, header := range uncommittedBlockHeaderList {
@@ -526,12 +541,6 @@ func (s *ShardBackend) broadcastNewTip() (err error) {
 
 	err = s.conn.BroadcastNewTip([]*types.MinorBlockHeader{minorTip}, rootTip.Header(), s.branch.Value)
 	return
-}
-
-func (s *ShardBackend) setHead(head uint64) {
-	if err := s.MinorBlockChain.SetHead(head); err != nil {
-		panic(err)
-	}
 }
 
 func (s *ShardBackend) AddTxList(txs []*types.Transaction) error {

--- a/core/minorblockchain.go
+++ b/core/minorblockchain.go
@@ -730,33 +730,38 @@ func (m *MinorBlockChain) procFutureBlocks() {
 }
 
 // RollbackToBlock rolls back the chain so that the block with targetHash
-// becomes the new current head. All blocks above targetHash (up to the
-// current tip) are removed from the database — body, receipts, commit
-// marker, and canonical hash mapping — so that HasBlock returns false
-// for each removed block and they can be re-inserted later.
+// becomes the new current head. Blocks above targetHash have their commit
+// marker and canonical hash mapping removed so they can be re-inserted later.
+// Block body and receipts are kept to avoid re-executing state.
 //
-// Unlike SetHead, this method does not acquire chainmu or purge caches.
-// It is intended for fast rollback in the shard layer (e.g. when
-// broadcasting xshard txs fails after a block was inserted). The caller
-// must hold the shard's mu lock to prevent concurrent insert/setHead.
+// The caller must ensure targetHash is an ancestor of the current head
+// (same chain). RollbackToBlock does not acquire chainmu; the caller must
+// hold the shard's mu lock to prevent concurrent inserts.
 func (m *MinorBlockChain) RollbackToBlock(targetHash common.Hash) error {
 	target := m.GetMinorBlock(targetHash)
 	if target == nil {
 		return fmt.Errorf("RollbackToBlock: target block %x not found", targetHash)
 	}
 
-	for cur := m.CurrentBlock(); cur != nil && cur.Hash() != targetHash; cur = m.CurrentBlock() {
-		if cur.NumberU64() < target.NumberU64() {
-			return fmt.Errorf("RollbackToBlock: overshot target %x (cur %d < target %d)", targetHash, cur.NumberU64(), target.NumberU64())
+	// Verify target is on the same chain (ancestor of current head).
+	for cur := m.CurrentBlock(); ; cur = m.GetMinorBlock(cur.ParentHash()) {
+		if cur == nil {
+			return fmt.Errorf("RollbackToBlock: target %x is not an ancestor of current head", targetHash)
 		}
+		if cur.Hash() == targetHash {
+			break
+		}
+		if cur.NumberU64() < target.NumberU64() || cur.NumberU64() == 0 {
+			return fmt.Errorf("RollbackToBlock: target %x is not an ancestor of current head", targetHash)
+		}
+	}
+
+	for cur := m.CurrentBlock(); cur != nil && cur.Hash() != targetHash; cur = m.CurrentBlock() {
 		parent := m.GetMinorBlock(cur.ParentHash())
 		if parent == nil {
 			return fmt.Errorf("RollbackToBlock: parent missing for block %d [%x]", cur.NumberU64(), cur.Hash())
 		}
-
 		batch := m.db.NewBatch()
-		rawdb.DeleteMinorBlock(batch, cur.Hash())
-		rawdb.DeleteReceipts(batch, cur.Hash())
 		rawdb.DeleteMinorBlockCommitStatus(batch, cur.Hash())
 		rawdb.DeleteCanonicalHash(batch, rawdb.ChainTypeMinor, cur.NumberU64())
 		if err := batch.Write(); err != nil {
@@ -764,6 +769,7 @@ func (m *MinorBlockChain) RollbackToBlock(targetHash common.Hash) error {
 		}
 		m.currentBlock.Store(parent)
 	}
+	rawdb.WriteHeadBlockHash(m.db, targetHash)
 	return nil
 }
 
@@ -1473,11 +1479,15 @@ func (m *MinorBlockChain) reorg(oldBlock, newBlock types.IBlock) error {
 		for i := len(oldChain) - 1; i >= 0; i-- {
 			rawdb.DeleteCanonicalHash(batch, rawdb.ChainTypeMinor, oldChain[i].NumberU64())
 		}
-		m.insert(newBlock.(*types.MinorBlock))
-		log.Warn(m.logInfo+" same chain reorg, set currentBlock", "number", newBlockNumber, "hash", newBlock.Hash())
 	}
 
 	batch.Write()
+
+	if len(newChain) == 0 {
+		// insert after batch.Write() so the head pointer is persisted after canonical deletes
+		m.insert(newBlock.(*types.MinorBlock))
+		log.Warn(m.logInfo+" same chain reorg, set currentBlock", "number", newBlockNumber, "hash", newBlock.Hash())
+	}
 
 	// Insert the new chain, taking care of the proper incremental order
 	for i := len(newChain) - 1; i >= 0; i-- {

--- a/core/minorblockchain.go
+++ b/core/minorblockchain.go
@@ -320,19 +320,19 @@ func (m *MinorBlockChain) setHead(head uint64) error {
 	// Rewind the header chain, deleting all block bodies until then
 	batch := m.db.NewBatch()
 	for block := m.CurrentBlock(); block != nil && block.NumberU64() > head; block = m.CurrentBlock() {
+		preBlock := m.GetMinorBlock(block.ParentHash())
+		if preBlock == nil {
+			return fmt.Errorf("Rewind block missing parent: %d, hash: %s", block.NumberU64(), block.Hash().Hex())
+		}
 		rawdb.DeleteMinorBlock(batch, block.Hash())
 		rawdb.DeleteCanonicalHash(batch, rawdb.ChainTypeMinor, block.NumberU64())
-		m.currentBlock.Store(m.GetBlock(block.ParentHash()))
+		m.currentBlock.Store(preBlock)
 	}
 	batch.Write()
-	if currentBlock := m.CurrentBlock(); currentBlock != nil {
-		if _, err := m.StateAt(currentBlock.GetMetaData().Root); err != nil {
-			// Rewound state missing, rolled back to before pivot, reset to genesis
-			m.currentBlock.Store(m.genesisBlock)
-		}
-	}
-
-	// If either blocks reached nil, reset to the genesis state
+	// Do NOT reset currentBlock to genesis when state is missing here.
+	// InitFromRootBlock calls reRunBlockWithState to rebuild missing state before
+	// calling setHead; resetting to genesis would undo that work and leave the
+	// chain stuck at height 0. The missing-state case is handled by the caller.
 	if currentBlock := m.CurrentBlock(); currentBlock == nil {
 		m.currentBlock.Store(m.genesisBlock)
 	}
@@ -525,8 +525,12 @@ func (m *MinorBlockChain) ExportN(w io.Writer, first uint64, last uint64) error 
 // Note, this function assumes that the `mu` mutex is held!
 func (m *MinorBlockChain) insert(block *types.MinorBlock) {
 	// Add the block to the canonical chain number scheme and mark as the head
-	rawdb.WriteCanonicalHash(m.db, rawdb.ChainTypeMinor, block.Hash(), block.NumberU64())
-	rawdb.WriteHeadBlockHash(m.db, block.Hash())
+	batch := m.db.NewBatch()
+	rawdb.WriteCanonicalHash(batch, rawdb.ChainTypeMinor, block.Hash(), block.NumberU64())
+	rawdb.WriteHeadBlockHash(batch, block.Hash())
+	if err := batch.Write(); err != nil {
+		log.Error(m.logInfo, "Failed to write head block hash to database", "hash", block.Hash(), "number", block.NumberU64(), "err", err)
+	}
 
 	m.currentBlock.Store(block)
 }
@@ -723,6 +727,44 @@ func (m *MinorBlockChain) procFutureBlocks() {
 			m.InsertChain(blocks[i:i+1], false)
 		}
 	}
+}
+
+// RollbackToBlock rolls back the chain so that the block with targetHash
+// becomes the new current head. All blocks above targetHash (up to the
+// current tip) are removed from the database — body, receipts, commit
+// marker, and canonical hash mapping — so that HasBlock returns false
+// for each removed block and they can be re-inserted later.
+//
+// Unlike SetHead, this method does not acquire chainmu or purge caches.
+// It is intended for fast rollback in the shard layer (e.g. when
+// broadcasting xshard txs fails after a block was inserted). The caller
+// must hold the shard's mu lock to prevent concurrent insert/setHead.
+func (m *MinorBlockChain) RollbackToBlock(targetHash common.Hash) error {
+	target := m.GetMinorBlock(targetHash)
+	if target == nil {
+		return fmt.Errorf("RollbackToBlock: target block %x not found", targetHash)
+	}
+
+	for cur := m.CurrentBlock(); cur != nil && cur.Hash() != targetHash; cur = m.CurrentBlock() {
+		if cur.NumberU64() < target.NumberU64() {
+			return fmt.Errorf("RollbackToBlock: overshot target %x (cur %d < target %d)", targetHash, cur.NumberU64(), target.NumberU64())
+		}
+		parent := m.GetMinorBlock(cur.ParentHash())
+		if parent == nil {
+			return fmt.Errorf("RollbackToBlock: parent missing for block %d [%x]", cur.NumberU64(), cur.Hash())
+		}
+
+		batch := m.db.NewBatch()
+		rawdb.DeleteMinorBlock(batch, cur.Hash())
+		rawdb.DeleteReceipts(batch, cur.Hash())
+		rawdb.DeleteMinorBlockCommitStatus(batch, cur.Hash())
+		rawdb.DeleteCanonicalHash(batch, rawdb.ChainTypeMinor, cur.NumberU64())
+		if err := batch.Write(); err != nil {
+			return fmt.Errorf("RollbackToBlock: batch write failed: %w", err)
+		}
+		m.currentBlock.Store(parent)
+	}
+	return nil
 }
 
 // Rollback is designed to remove a chain of links from the database that aren't
@@ -1415,9 +1457,6 @@ func (m *MinorBlockChain) reorg(oldBlock, newBlock types.IBlock) error {
 		// we support reorg block from same chain,because we should delete and add tx index
 		log.Warn(m.logInfo+" reorg", "same chain curr", m.CurrentBlock().NumberU64(), "curr.Hash", m.CurrentBlock().Hash().TerminalString(),
 			"newBlock", newBlockNumber, "newBlock's hash", newBlockHash, "newBlock", m.GetMinorBlock(newBlockHash) == nil)
-		if err := m.setHead(newBlockNumber); err != nil {
-			return err
-		}
 	}
 
 	// When transactions get deleted from the database that means the
@@ -1427,6 +1466,15 @@ func (m *MinorBlockChain) reorg(oldBlock, newBlock types.IBlock) error {
 		if err := m.removeTxIndexFromBlock(batch, oldChain[i].(*types.MinorBlock)); err != nil {
 			return err
 		}
+	}
+
+	if len(newChain) == 0 {
+		// same-chain reorg: delete canonical hashes for displaced blocks
+		for i := len(oldChain) - 1; i >= 0; i-- {
+			rawdb.DeleteCanonicalHash(batch, rawdb.ChainTypeMinor, oldChain[i].NumberU64())
+		}
+		m.insert(newBlock.(*types.MinorBlock))
+		log.Warn(m.logInfo+" same chain reorg, set currentBlock", "number", newBlockNumber, "hash", newBlock.Hash())
 	}
 
 	batch.Write()

--- a/core/minorblockchain.go
+++ b/core/minorblockchain.go
@@ -472,9 +472,7 @@ func (m *MinorBlockChain) ResetWithGenesisBlock(genesis *types.MinorBlock) error
 	rawdb.WriteMinorBlock(m.db, genesis)
 
 	m.genesisBlock = genesis
-	if err := m.insert(m.genesisBlock); err != nil {
-		log.Crit(m.logInfo+" Failed to insert genesis block", "err", err)
-	}
+	m.insert(m.genesisBlock)
 	m.currentBlock.Store(m.genesisBlock)
 
 	return nil
@@ -525,17 +523,11 @@ func (m *MinorBlockChain) ExportN(w io.Writer, first uint64, last uint64) error 
 // or if they are on a different side chain.
 //
 // Note, this function assumes that the `mu` mutex is held!
-func (m *MinorBlockChain) insert(block *types.MinorBlock) error {
-	// Add the block to the canonical chain number scheme and mark as the head
-	batch := m.db.NewBatch()
-	rawdb.WriteCanonicalHash(batch, rawdb.ChainTypeMinor, block.Hash(), block.NumberU64())
-	rawdb.WriteHeadBlockHash(batch, block.Hash())
-	if err := batch.Write(); err != nil {
-		return fmt.Errorf("failed to write head block hash to database: %w", err)
-	}
+func (m *MinorBlockChain) insert(block *types.MinorBlock) {
+	rawdb.WriteCanonicalHash(m.db, rawdb.ChainTypeMinor, block.Hash(), block.NumberU64())
+	rawdb.WriteHeadBlockHash(m.db, block.Hash())
 
 	m.currentBlock.Store(block)
-	return nil
 }
 
 // Genesis retrieves the chain's genesis block.
@@ -1045,9 +1037,7 @@ func (m *MinorBlockChain) WriteBlockWithState(block *types.MinorBlock, receipts 
 
 	// Set new head.
 	if status == CanonStatTy {
-		if err := m.insert(block); err != nil {
-			return NonStatTy, err
-		}
+		m.insert(block)
 	}
 	m.CommitMinorBlockByHash(block.Hash())
 	m.futureBlocks.Remove(block.Hash())
@@ -1503,18 +1493,14 @@ func (m *MinorBlockChain) reorg(oldBlock, newBlock types.IBlock) error {
 
 	if len(newChain) == 0 {
 		// insert after batch.Write() so the head pointer is persisted after canonical deletes
-		if err := m.insert(newBlock.(*types.MinorBlock)); err != nil {
-			return err
-		}
+		m.insert(newBlock.(*types.MinorBlock))
 		log.Warn(m.logInfo+" same chain reorg, set currentBlock", "number", newBlockNumber, "hash", newBlock.Hash())
 	}
 
 	// Insert the new chain, taking care of the proper incremental order
 	for i := len(newChain) - 1; i >= 0; i-- {
 		// insert the block in the canonical way, re-writing history
-		if err := m.insert(newChain[i].(*types.MinorBlock)); err != nil {
-			return err
-		}
+		m.insert(newChain[i].(*types.MinorBlock))
 		// write lookup entries for hash based transaction/receipt searches
 		if err := m.putTxIndexFromBlock(m.db, newChain[i]); err != nil {
 			return err

--- a/core/minorblockchain.go
+++ b/core/minorblockchain.go
@@ -472,7 +472,9 @@ func (m *MinorBlockChain) ResetWithGenesisBlock(genesis *types.MinorBlock) error
 	rawdb.WriteMinorBlock(m.db, genesis)
 
 	m.genesisBlock = genesis
-	m.insert(m.genesisBlock)
+	if err := m.insert(m.genesisBlock); err != nil {
+		log.Crit(m.logInfo+" Failed to insert genesis block", "err", err)
+	}
 	m.currentBlock.Store(m.genesisBlock)
 
 	return nil
@@ -523,16 +525,17 @@ func (m *MinorBlockChain) ExportN(w io.Writer, first uint64, last uint64) error 
 // or if they are on a different side chain.
 //
 // Note, this function assumes that the `mu` mutex is held!
-func (m *MinorBlockChain) insert(block *types.MinorBlock) {
+func (m *MinorBlockChain) insert(block *types.MinorBlock) error {
 	// Add the block to the canonical chain number scheme and mark as the head
 	batch := m.db.NewBatch()
 	rawdb.WriteCanonicalHash(batch, rawdb.ChainTypeMinor, block.Hash(), block.NumberU64())
 	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	if err := batch.Write(); err != nil {
-		log.Error(m.logInfo, "Failed to write head block hash to database", "hash", block.Hash(), "number", block.NumberU64(), "err", err)
+		return fmt.Errorf("failed to write head block hash to database: %w", err)
 	}
 
 	m.currentBlock.Store(block)
+	return nil
 }
 
 // Genesis retrieves the chain's genesis block.
@@ -731,13 +734,15 @@ func (m *MinorBlockChain) procFutureBlocks() {
 
 // RollbackToBlock rolls back the chain so that the block with targetHash
 // becomes the new current head. Blocks above targetHash have their commit
-// marker and canonical hash mapping removed so they can be re-inserted later.
-// Block body and receipts are kept to avoid re-executing state.
+// marker, tx indexes, and canonical hash mapping removed so they can be
+// re-inserted later.
 //
 // The caller must ensure targetHash is an ancestor of the current head
-// (same chain). RollbackToBlock does not acquire chainmu; the caller must
-// hold the shard's mu lock to prevent concurrent inserts.
+// (same chain).
 func (m *MinorBlockChain) RollbackToBlock(targetHash common.Hash) error {
+	m.chainmu.Lock()
+	defer m.chainmu.Unlock()
+
 	target := m.GetMinorBlock(targetHash)
 	if target == nil {
 		return fmt.Errorf("RollbackToBlock: target block %x not found", targetHash)
@@ -756,19 +761,24 @@ func (m *MinorBlockChain) RollbackToBlock(targetHash common.Hash) error {
 		}
 	}
 
-	for cur := m.CurrentBlock(); cur != nil && cur.Hash() != targetHash; cur = m.CurrentBlock() {
+	// Delete commit markers, tx indexes, and canonical hashes in a single batch
+	batch := m.db.NewBatch()
+	for cur := m.CurrentBlock(); cur != nil && cur.Hash() != targetHash; cur = m.GetMinorBlock(cur.ParentHash()) {
 		parent := m.GetMinorBlock(cur.ParentHash())
 		if parent == nil {
 			return fmt.Errorf("RollbackToBlock: parent missing for block %d [%x]", cur.NumberU64(), cur.Hash())
 		}
-		batch := m.db.NewBatch()
 		rawdb.DeleteMinorBlockCommitStatus(batch, cur.Hash())
 		rawdb.DeleteCanonicalHash(batch, rawdb.ChainTypeMinor, cur.NumberU64())
-		if err := batch.Write(); err != nil {
-			return fmt.Errorf("RollbackToBlock: batch write failed: %w", err)
+		if err := m.removeTxIndexFromBlock(batch, cur); err != nil {
+			return fmt.Errorf("RollbackToBlock: failed to remove tx index for block %d [%x]: %w", cur.NumberU64(), cur.Hash(), err)
 		}
 		m.currentBlock.Store(parent)
 	}
+	if err := batch.Write(); err != nil {
+		return fmt.Errorf("RollbackToBlock: batch write failed: %w", err)
+	}
+
 	rawdb.WriteHeadBlockHash(m.db, targetHash)
 	return nil
 }
@@ -1031,7 +1041,9 @@ func (m *MinorBlockChain) WriteBlockWithState(block *types.MinorBlock, receipts 
 
 	// Set new head.
 	if status == CanonStatTy {
-		m.insert(block)
+		if err := m.insert(block); err != nil {
+			return NonStatTy, err
+		}
 	}
 	m.CommitMinorBlockByHash(block.Hash())
 	m.futureBlocks.Remove(block.Hash())
@@ -1481,18 +1493,24 @@ func (m *MinorBlockChain) reorg(oldBlock, newBlock types.IBlock) error {
 		}
 	}
 
-	batch.Write()
+	if err := batch.Write(); err != nil {
+		return fmt.Errorf("reorg: failed to write tx index deletions: %w", err)
+	}
 
 	if len(newChain) == 0 {
 		// insert after batch.Write() so the head pointer is persisted after canonical deletes
-		m.insert(newBlock.(*types.MinorBlock))
+		if err := m.insert(newBlock.(*types.MinorBlock)); err != nil {
+			return err
+		}
 		log.Warn(m.logInfo+" same chain reorg, set currentBlock", "number", newBlockNumber, "hash", newBlock.Hash())
 	}
 
 	// Insert the new chain, taking care of the proper incremental order
 	for i := len(newChain) - 1; i >= 0; i-- {
 		// insert the block in the canonical way, re-writing history
-		m.insert(newChain[i].(*types.MinorBlock))
+		if err := m.insert(newChain[i].(*types.MinorBlock)); err != nil {
+			return err
+		}
 		// write lookup entries for hash based transaction/receipt searches
 		if err := m.putTxIndexFromBlock(m.db, newChain[i]); err != nil {
 			return err

--- a/core/minorblockchain_addon.go
+++ b/core/minorblockchain_addon.go
@@ -539,9 +539,10 @@ func (m *MinorBlockChain) reRunBlockWithState(block *types.MinorBlock) error {
 			break
 		}
 		blockWithoutState = append(blockWithoutState, block)
-		block = m.GetMinorBlock(block.ParentHash())
+		parentHash := block.ParentHash()
+		block = m.GetMinorBlock(parentHash)
 		if qkcCommon.IsNil(block) {
-			return fmt.Errorf("missing block %d [%x]", block.NumberU64(), block.Hash().String())
+			return fmt.Errorf("missing block with parent hash %x", parentHash)
 		}
 	}
 

--- a/core/minorblockchain_test.go
+++ b/core/minorblockchain_test.go
@@ -214,8 +214,8 @@ func TestMinorLastBlock(t *testing.T) {
 	}
 }
 
-//TestMinors that given a starting canonical chain of a given size, it can be extended
-//with various length chains.
+// TestMinors that given a starting canonical chain of a given size, it can be extended
+// with various length chains.
 func TestMinorExtendCanonicalBlocks(t *testing.T) { testMinorExtendCanonical(t, true) }
 
 func testMinorExtendCanonical(t *testing.T, full bool) {
@@ -241,8 +241,8 @@ func testMinorExtendCanonical(t *testing.T, full bool) {
 	testMinorFork(t, processor, length, 10, full, better)
 }
 
-//TestMinors that given a starting canonical chain of a given size, creating shorter
-//forks do not take canonical ownership.
+// TestMinors that given a starting canonical chain of a given size, creating shorter
+// forks do not take canonical ownership.
 func TestMinorShorterForkBlocks(t *testing.T) { testMinorShorterFork(t, true) }
 
 func testMinorShorterFork(t *testing.T, full bool) {
@@ -270,8 +270,8 @@ func testMinorShorterFork(t *testing.T, full bool) {
 	testMinorFork(t, processor, 5, 4, full, worse)
 }
 
-//TestMinors that given a starting canonical chain of a given size, creating longer
-//forks do take canonical ownership.
+// TestMinors that given a starting canonical chain of a given size, creating longer
+// forks do take canonical ownership.
 func TestMinorLongerForkBlocks(t *testing.T) { testMinorLongerFork(t, true) }
 
 func testMinorLongerFork(t *testing.T, full bool) {
@@ -299,9 +299,8 @@ func testMinorLongerFork(t *testing.T, full bool) {
 	testMinorFork(t, processor, 5, 8, full, better)
 }
 
-//
-//TestMinors that given a starting canonical chain of a given size, creating equal
-//forks do take canonical ownership.
+// TestMinors that given a starting canonical chain of a given size, creating equal
+// forks do take canonical ownership.
 func TestMinorEqualForkBlocks(t *testing.T) { testMinorEqualFork(t, true) }
 
 func testMinorEqualFork(t *testing.T, full bool) {
@@ -358,9 +357,8 @@ func testMinorBrokenChain(t *testing.T, full bool) {
 	}
 }
 
-//
-//TestMinors that reorganising a long difficult chain after a short easy one
-//overwrites the canonical numbers and links in the database.
+// TestMinors that reorganising a long difficult chain after a short easy one
+// overwrites the canonical numbers and links in the database.
 func TestMinorReorgLongBlocks(t *testing.T) { testMinorReorgLong(t, true) }
 
 func testMinorReorgLong(t *testing.T, full bool) {
@@ -1360,6 +1358,94 @@ func TestMinorLargeReorgTrieGC(t *testing.T) {
 		if node, _ := chain.stateCache.TrieDB().Node(block.Root()); node == nil {
 			t.Fatalf("competitor %d: competing chain state missing", i)
 		}
+	}
+}
+
+// TestRollbackToBlock verifies that RollbackToBlock removes all blocks above
+// the target from the database and correctly restores currentBlock to target.
+func TestRollbackToBlock(t *testing.T) {
+	_, blockchain, err := newMinorCanonical(nil, engine, 3, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer blockchain.Stop()
+
+	blocks := makeBlockChain(blockchain.CurrentBlock(), 2, engine, blockchain.db, 42)
+	block4, block5 := blocks[0], blocks[1]
+	if _, err := blockchain.InsertChain(toMinorBlocks(blocks), false); err != nil {
+		t.Fatal(err)
+	}
+	if blockchain.CurrentBlock().Hash() != block5.Hash() {
+		t.Fatalf("expected current block to be block5 after insert")
+	}
+
+	block3Hash := block4.ParentHash()
+	if err := blockchain.RollbackToBlock(block3Hash); err != nil {
+		t.Fatalf("RollbackToBlock failed: %v", err)
+	}
+
+	if blockchain.CurrentBlock().Hash() != block3Hash {
+		t.Fatalf("after rollback currentBlock = %x, want %x", blockchain.CurrentBlock().Hash(), block3Hash)
+	}
+	if rawdb.HasBlock(blockchain.db, block4.Hash()) {
+		t.Fatal("block4 body still present after rollback")
+	}
+	if rawdb.HasBlock(blockchain.db, block5.Hash()) {
+		t.Fatal("block5 body still present after rollback")
+	}
+	if rawdb.HasCommitMinorBlock(blockchain.db, block4.Hash()) {
+		t.Fatal("block4 commit marker still present after rollback")
+	}
+	if rawdb.HasCommitMinorBlock(blockchain.db, block5.Hash()) {
+		t.Fatal("block5 commit marker still present after rollback")
+	}
+	if rawdb.ReadCanonicalHash(blockchain.db, rawdb.ChainTypeMinor, block4.NumberU64()) == block4.Hash() {
+		t.Fatal("block4 canonical hash still present after rollback")
+	}
+	if rawdb.ReadCanonicalHash(blockchain.db, rawdb.ChainTypeMinor, block5.NumberU64()) == block5.Hash() {
+		t.Fatal("block5 canonical hash still present after rollback")
+	}
+
+	// Re-insertion after rollback must succeed.
+	if _, err := blockchain.InsertChain(toMinorBlocks(blocks), false); err != nil {
+		t.Fatalf("re-insert after rollback failed: %v", err)
+	}
+	if blockchain.CurrentBlock().Hash() != block5.Hash() {
+		t.Fatalf("expected current block to be block5 after re-insert")
+	}
+}
+
+// TestSameChainReorgClearsOldCanonicalHashes verifies that a same-chain reorg
+// (newBlock is already canonical but at a lower height than currentBlock)
+// clears the canonical hash mappings for the displaced blocks.
+func TestSameChainReorgClearsOldCanonicalHashes(t *testing.T) {
+	_, blockchain, err := newMinorCanonical(nil, engine, 5, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer blockchain.Stop()
+
+	// Record block hashes at heights 4 and 5 before reorg.
+	block5 := blockchain.GetBlockByNumber(5).(*types.MinorBlock)
+	block4 := blockchain.GetBlockByNumber(4).(*types.MinorBlock)
+	block3 := blockchain.GetBlockByNumber(3).(*types.MinorBlock)
+
+	// Trigger same-chain reorg directly: block3 is an ancestor of block5 on
+	// the same chain, so reorg() will see oldChain=[B5,B4] and newChain=[].
+	if err := blockchain.reorg(block5, block3); err != nil {
+		t.Fatalf("same-chain reorg failed: %v", err)
+	}
+
+	// After reorg to block3, canonical hashes for 4 and 5 must be cleared.
+	if rawdb.ReadCanonicalHash(blockchain.db, rawdb.ChainTypeMinor, 4) == block4.Hash() {
+		t.Fatal("canonical hash at height 4 should be cleared after same-chain reorg")
+	}
+	if rawdb.ReadCanonicalHash(blockchain.db, rawdb.ChainTypeMinor, 5) == block5.Hash() {
+		t.Fatal("canonical hash at height 5 should be cleared after same-chain reorg")
+	}
+	// currentBlock must now be block3.
+	if blockchain.CurrentBlock().Hash() != block3.Hash() {
+		t.Fatalf("currentBlock = %x, want block3 %x", blockchain.CurrentBlock().Hash(), block3.Hash())
 	}
 }
 

--- a/core/minorblockchain_test.go
+++ b/core/minorblockchain_test.go
@@ -1398,7 +1398,7 @@ func TestVerifyHeaderTypedNilParentReturnsErrUnknownAncestor(t *testing.T) {
 		t.Fatalf("expected ErrUnknownAncestor, got %v", err)
 	}
 }
-	
+
 // TestRollbackToBlock verifies that RollbackToBlock clears commit markers and
 // canonical hashes for blocks above the target, keeps block bodies intact,
 // and correctly restores currentBlock to target.
@@ -1488,24 +1488,6 @@ func TestSameChainReorgClearsOldCanonicalHashes(t *testing.T) {
 	// currentBlock must now be block3.
 	if blockchain.CurrentBlock().Hash() != block3.Hash() {
 		t.Fatalf("currentBlock = %x, want block3 %x", blockchain.CurrentBlock().Hash(), block3.Hash())
-	// Build block 4 and write only its header to rawdb (no body),
-	// simulating the state where parent hash is referenced but body is absent.
-	block4 := makeBlockChain(blockchain.CurrentBlock(), 1, eng, blockchain.db, 42)[0]
-	rawdb.WriteMinorBlock(blockchain.db, block4)
-	blockchain.blockCache.Purge()
-	rawdb.DeleteBlock(blockchain.db, block4.Hash())
-	blockchain.blockCache.Purge()
-
-	// Build block 5 referencing block 4 as parent.
-	block5 := makeBlockChain(block4, 1, eng, blockchain.db, 42)[0]
-
-	// Call engine.VerifyHeader directly. It calls chain.GetBlock(block4.Hash()).
-	// Body is absent → GetMinorBlock returns nil → GetBlock returns typed-nil IBlock.
-	// Without the fix: parent == nil is false → panic on parent.NumberU64().
-	// With the fix: qkccommon.IsNil(parent) is true → returns ErrUnknownAncestor.
-	err = blockchain.engine.VerifyHeader(blockchain, block5.IHeader(), false)
-	if !errors.Is(err, consensus.ErrUnknownAncestor) {
-		t.Fatalf("expected ErrUnknownAncestor, got %v", err)
 	}
 }
 

--- a/core/minorblockchain_test.go
+++ b/core/minorblockchain_test.go
@@ -1361,8 +1361,9 @@ func TestMinorLargeReorgTrieGC(t *testing.T) {
 	}
 }
 
-// TestRollbackToBlock verifies that RollbackToBlock removes all blocks above
-// the target from the database and correctly restores currentBlock to target.
+// TestRollbackToBlock verifies that RollbackToBlock clears commit markers and
+// canonical hashes for blocks above the target, keeps block bodies intact,
+// and correctly restores currentBlock to target.
 func TestRollbackToBlock(t *testing.T) {
 	_, blockchain, err := newMinorCanonical(nil, engine, 3, true)
 	if err != nil {
@@ -1387,23 +1388,26 @@ func TestRollbackToBlock(t *testing.T) {
 	if blockchain.CurrentBlock().Hash() != block3Hash {
 		t.Fatalf("after rollback currentBlock = %x, want %x", blockchain.CurrentBlock().Hash(), block3Hash)
 	}
-	if rawdb.HasBlock(blockchain.db, block4.Hash()) {
-		t.Fatal("block4 body still present after rollback")
+	// Block bodies must still be present (not deleted by rollback).
+	if !rawdb.HasBlock(blockchain.db, block4.Hash()) {
+		t.Fatal("block4 body should still be present after rollback")
 	}
-	if rawdb.HasBlock(blockchain.db, block5.Hash()) {
-		t.Fatal("block5 body still present after rollback")
+	if !rawdb.HasBlock(blockchain.db, block5.Hash()) {
+		t.Fatal("block5 body should still be present after rollback")
 	}
+	// Commit markers must be cleared.
 	if rawdb.HasCommitMinorBlock(blockchain.db, block4.Hash()) {
-		t.Fatal("block4 commit marker still present after rollback")
+		t.Fatal("block4 commit marker should be cleared after rollback")
 	}
 	if rawdb.HasCommitMinorBlock(blockchain.db, block5.Hash()) {
-		t.Fatal("block5 commit marker still present after rollback")
+		t.Fatal("block5 commit marker should be cleared after rollback")
 	}
+	// Canonical hashes must be cleared.
 	if rawdb.ReadCanonicalHash(blockchain.db, rawdb.ChainTypeMinor, block4.NumberU64()) == block4.Hash() {
-		t.Fatal("block4 canonical hash still present after rollback")
+		t.Fatal("block4 canonical hash should be cleared after rollback")
 	}
 	if rawdb.ReadCanonicalHash(blockchain.db, rawdb.ChainTypeMinor, block5.NumberU64()) == block5.Hash() {
-		t.Fatal("block5 canonical hash still present after rollback")
+		t.Fatal("block5 canonical hash should be cleared after rollback")
 	}
 
 	// Re-insertion after rollback must succeed.


### PR DESCRIPTION
###  Summary

  The post-insertion failure recovery in ShardBackend (xshard broadcast / master-notify / stats failures) had two problems:

  1. `AddBlockListForSync` never rolled back on failure. When `BatchBroadcastXshardTxList` or `SendMinorBlockHeaderListToMaster` failed, the code just `return err` — the blocks stayed inserted and canonical but uncommitted (`CommitMinorBlockByHash` only runs on success). On retry, `InsertChainForDeposits` hits `ErrKnownBlock` → `len(xshardLst) != 1` → early return `nil`, so `SendMinorBlockHeaderListToMaster` is skipped and the master never learns the block's coinbase — a permanent deadlock.
  2. `AddMinorBlock` recovered via `setHead`, which is heavier and riskier than needed. `setHead` calls `DeleteMinorBlock` (deletes body, receipts, and commit marker) plus `DeleteCanonicalHash` for every block above the target. That forces full state re-execution on retry, and it carries a "rewound state missing → reset to genesis" branch that can silently strand the chain at height 0.

  This branch introduces `RollbackToBlock`, which un-commits displaced blocks just enough to make them cleanly re-insertable (keeping body/receipts), wires it into both recovery paths, and fixes two persistence-ordering bugs in the same-chain reorg path.

###  Changes

  1. New `MinorBlockChain.RollbackToBlock(targetHash)` (`core/minorblockchain.go`)
  - For each block above the target, deletes only the commit marker (`DeleteMinorBlockCommitStatus`) and canonical-hash mapping (`DeleteCanonicalHash`) — keeps block body and receipts, so re-insertion skips re-writing bodies.
  - Verifies `targetHash` is an ancestor of the current head before rolling back.
  - Persists the new head via `WriteHeadBlockHash(targetHash)` at the end, so a crash after rollback restores the correct head rather than the block that failed broadcast.
  - Does not acquire `chainmu`; the caller must hold the shard mu lock.

  Contrast with `setHead`, which deletes bodies/receipts (forcing re-execution) and has the genesis-reset footgun.

  2. ShardBackend recovery uses RollbackToBlock (cluster/shard/api_backend.go)
  - `AddBlockListForSync`: records prevHead before the insertion loop and rolls back on `BatchBroadcastXshardTxList` / `SendMinorBlockHeaderListToMaster` failure — closing the master-coinbase deadlock.
  - `AddMinorBlock`: replaces the three `setHead(currHead.Number)` recovery calls (`BroadcastXshardTxList`, `GetShardStats`, `SendMinorBlockHeaderToMaster`) with `RollbackToBlock(currHead.Hash())`.
  - `broadcastNewTip` failure is demoted to a warn with no rollback — the block is fully committed locally and peers sync later; rolling back here would discard valid
  work.
  - Removed the now-unused `setHead` helper (which panic'd on error).

  3. Fixed same-chain reorg persistence (`core/minorblockchain.go`, `reorg()`)
  - The old code added `DeleteCanonicalHash` writes to the batch after `batch.Write()` had already `Destroy()`'d the underlying RocksDB WriteBatch, so the displaced canonical hashes were never persisted. Deletions now happen before `batch.Write()`.
  - `m.insert()` for the new head is now called after `batch.Write()`, so the head pointer is flushed only after the canonical-hash deletes and tx-index removals — matching the cross-chain path's ordering.

  4. `insert()` writes canonical + head hash atomically (`core/minorblockchain.go`) via a single batch, with error logging instead of silent failure.

  5. `setHead` genesis-reset removed (`core/minorblockchain.go`): the "rewound state missing → reset to genesis" branch is dropped. `InitFromRootBlock` rebuilds missing state via `reRunBlockWithState` before calling `setHead`; resetting to genesis here would undo that and strand the chain at height 0. The missing-state case is now the
  caller's responsibility.

  6. Minor fix (`core/minorblockchain_addon.go`): `reRunBlockWithState`'s "missing block" error no longer dereferences the nil block; it reports the parent hash instead.

###  Tests (`core/minorblockchain_test.go`)

  - `TestRollbackToBlock`: asserts commit markers + canonical hashes are cleared, bodies are kept, `currentBlock` is restored to target, and re-insertion succeeds.
  - `TestSameChainReorgClearsOldCanonicalHashes`: drives `reorg(block5,` block3) directly (an already-canonical `InsertChain` would hit the `ErrKnownBlock` path and never call `reorg`) and asserts displaced canonical hashes at heights 4 & 5 are cleared.