### PR TITLE
test: replace bou.ke/monkey with function-variable test seams

### DIFF
--- a/cluster/master/backend.go
+++ b/cluster/master/backend.go
@@ -136,7 +136,9 @@ func New(ctx *service.ServiceContext, cfg *config.ClusterConfig) (*QKCMasterBack
 	return mstr, nil
 }
 
-func createDB(ctx *service.ServiceContext, name string, clean bool, isReadOnly bool) (ethdb.Database, error) {
+// createDB is a package-level variable (rather than a plain func) so that tests
+// can swap in a stub without machine-code patching, which is unsupported on macOS.
+var createDB = func(ctx *service.ServiceContext, name string, clean bool, isReadOnly bool) (ethdb.Database, error) {
 	db, err := ctx.OpenDatabase(name, clean, isReadOnly)
 	if err != nil {
 		return nil, err

--- a/cluster/master/master_test.go
+++ b/cluster/master/master_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/QuarkChain/goquarkchain/account"
 	"github.com/QuarkChain/goquarkchain/cluster/config"
 	"github.com/QuarkChain/goquarkchain/cluster/rpc"
@@ -268,7 +267,15 @@ func initEnv(t *testing.T, chanOp chan uint32) *QKCMasterBackend {
 }
 
 func initEnvWithConsensusType(t *testing.T, chanOp chan uint32, consensusType string, pubKey string) *QKCMasterBackend {
-	monkey.Patch(NewSlaveConn, func(target string, shardMaskLst []uint32, slaveID string) *SlaveConnection {
+	// Stub NewSlaveConn/createDB only for the duration of backend construction
+	// below, then restore. This replaces bou.ke/monkey machine-code patching,
+	// which macOS forbids (W^X).
+	origNewSlaveConn, origCreateDB := NewSlaveConn, createDB
+	defer func() {
+		NewSlaveConn = origNewSlaveConn
+		createDB = origCreateDB
+	}()
+	NewSlaveConn = func(target string, shardMaskLst []uint32, slaveID string) *SlaveConnection {
 		client := NewFakeRPCClient(chanOp, target, shardMaskLst, slaveID, config.NewClusterConfig())
 		return &SlaveConnection{
 			target:        target,
@@ -276,11 +283,10 @@ func initEnvWithConsensusType(t *testing.T, chanOp chan uint32, consensusType st
 			shardMaskList: shardMaskLst,
 			slaveID:       slaveID,
 		}
-	})
-	monkey.Patch(createDB, func(ctx *service.ServiceContext, name string, clean bool, isReadOnly bool) (ethdb.Database, error) {
+	}
+	createDB = func(ctx *service.ServiceContext, name string, clean bool, isReadOnly bool) (ethdb.Database, error) {
 		return service.NewQkcMemoryDB(isReadOnly), nil
-	})
-	defer monkey.UnpatchAll()
+	}
 
 	ctx := &service.ServiceContext{}
 	clusterConfig := config.NewClusterConfig()

--- a/cluster/master/slave_connection.go
+++ b/cluster/master/slave_connection.go
@@ -87,7 +87,9 @@ type SlaveConnection struct {
 }
 
 // create slave connection manager
-func NewSlaveConn(target string, shardMaskList []uint32, slaveID string) *SlaveConnection {
+// NewSlaveConn is a package-level variable (rather than a plain func) so that tests
+// can swap in a stub without machine-code patching, which is unsupported on macOS.
+var NewSlaveConn = func(target string, shardMaskList []uint32, slaveID string) *SlaveConnection {
 	client := rpc.NewClient(rpc.SlaveServer)
 	return &SlaveConnection{
 		target:        target,

--- a/core/native_test.go
+++ b/core/native_test.go
@@ -5,8 +5,7 @@ import (
 	"math/big"
 	"os"
 	"testing"
-	"bou.ke/monkey"
-	
+
 	"github.com/QuarkChain/goquarkchain/params"
 	ethParams "github.com/ethereum/go-ethereum/params"
 	"github.com/QuarkChain/goquarkchain/account"
@@ -118,14 +117,25 @@ func TestDisallowedUnknownToken(t *testing.T) {
 	assert.Error(t, shardState.AddTx(tx2))
 }
 
+// stubNativeTokenGas swaps the native-token gas conversion functions for
+// fixed-rate stubs for the duration of the test, restoring them on cleanup.
+// This replaces bou.ke/monkey machine-code patching, which macOS forbids (W^X).
+func stubNativeTokenGas(t *testing.T) {
+	origPay, origInfo := PayNativeTokenAsGas, GetGasUtilityInfo
+	t.Cleanup(func() {
+		PayNativeTokenAsGas = origPay
+		GetGasUtilityInfo = origInfo
+	})
+	PayNativeTokenAsGas = func(a vm.StateDB, b *ethParams.ChainConfig, c uint64, d uint64, gasPrice *big.Int) (uint8, *big.Int, error) {
+		return 100, gasPrice, nil
+	}
+	GetGasUtilityInfo = func(a vm.StateDB, b *ethParams.ChainConfig, c uint64, gasPrice *big.Int) (uint8, *big.Int, error) {
+		return 100, gasPrice, nil
+	}
+}
+
 func TestNativeTokenGas(t *testing.T) {
-	monkey.Patch(PayNativeTokenAsGas, func(a vm.StateDB, b *ethParams.ChainConfig, c uint64, d uint64, gasPrice *big.Int) (uint8, *big.Int, error) {
-		return 100, gasPrice, nil
-	})
-	monkey.Patch(GetGasUtilityInfo, func(a vm.StateDB, b *ethParams.ChainConfig, c uint64, gasPrice *big.Int) (uint8, *big.Int, error) {
-		return 100, gasPrice, nil
-	})
-	defer monkey.UnpatchAll()
+	stubNativeTokenGas(t)
 	dirname, err := ioutil.TempDir(os.TempDir(), "qkcdb_test_")
 	if err != nil {
 		panic("failed to create test file: " + err.Error())
@@ -297,13 +307,7 @@ func TestXshardNativeTokenReceived(t *testing.T) {
 }
 
 func TestXshardNativeTokenGasSent(t *testing.T) {
-	monkey.Patch(PayNativeTokenAsGas, func(a vm.StateDB, b *ethParams.ChainConfig, c uint64, d uint64, gasPrice *big.Int) (uint8, *big.Int, error) {
-		return 100, gasPrice, nil
-	})
-	monkey.Patch(GetGasUtilityInfo, func(a vm.StateDB, b *ethParams.ChainConfig, c uint64, gasPrice *big.Int) (uint8, *big.Int, error) {
-		return 100, gasPrice, nil
-	})
-	defer monkey.UnpatchAll()
+	stubNativeTokenGas(t)
 	qeth := common.TokenIDEncode("QETHXX")
 	qkc := common.TokenIDEncode("QKC")
 	id1, _ := account.CreatRandomIdentity()

--- a/core/shardstate_test.go
+++ b/core/shardstate_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/QuarkChain/goquarkchain/account"
 	"github.com/QuarkChain/goquarkchain/cluster/config"
 	qkcCommon "github.com/QuarkChain/goquarkchain/common"
@@ -90,13 +89,7 @@ func TestInitGenesisState(t *testing.T) {
 }
 
 func TestGasPrice(t *testing.T) {
-	monkey.Patch(PayNativeTokenAsGas, func(a vm.StateDB, b *ethParams.ChainConfig, c uint64, d uint64, gasPrice *big.Int) (uint8, *big.Int, error) {
-		return 100, gasPrice, nil
-	})
-	monkey.Patch(GetGasUtilityInfo, func(a vm.StateDB, b *ethParams.ChainConfig, c uint64, gasPrice *big.Int) (uint8, *big.Int, error) {
-		return 100, gasPrice, nil
-	})
-	defer monkey.UnpatchAll()
+	stubNativeTokenGas(t)
 	addContractAddrBalance = true
 	defer func() {
 		addContractAddrBalance = false

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -320,7 +320,9 @@ func ApplyCrossShardDeposit(config *params.ChainConfig, bc ChainContext, header 
 	return nil, nil
 }
 
-func PayNativeTokenAsGas(evmState vm.StateDB, config *params.ChainConfig, tokenID, gas uint64,
+// PayNativeTokenAsGas is a package-level variable (rather than a plain func) so that
+// tests can swap in a stub without machine-code patching, which is unsupported on macOS.
+var PayNativeTokenAsGas = func(evmState vm.StateDB, config *params.ChainConfig, tokenID, gas uint64,
 	gasPriceInNativeToken *big.Int) (uint8, *big.Int, error) {
 	// not need to check gas(uint64)
 	if tokenID > qkcCmn.TOKENIDMAX || qkcCmn.BiggerThanUint128Max(gasPriceInNativeToken) {
@@ -335,7 +337,9 @@ func PayNativeTokenAsGas(evmState vm.StateDB, config *params.ChainConfig, tokenI
 	return callGeneralNativeTokenManager(evmState, config, data)
 }
 
-func GetGasUtilityInfo(evmState vm.StateDB, config *params.ChainConfig, tokenID uint64,
+// GetGasUtilityInfo is a package-level variable (rather than a plain func) so that
+// tests can swap in a stub without machine-code patching, which is unsupported on macOS.
+var GetGasUtilityInfo = func(evmState vm.StateDB, config *params.ChainConfig, tokenID uint64,
 	gasPriceInNativeToken *big.Int) (uint8, *big.Int, error) {
 
 	//# Call the `calculateGasPrice` function

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/QuarkChain/goquarkchain
 go 1.14
 
 require (
-	bou.ke/monkey v1.0.1
 	github.com/QuarkChain/goqkcclient v0.0.0-20191220040322-0b8ed7eb66e8
 	github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 // indirect
 	github.com/allegro/bigcache v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-bou.ke/monkey v1.0.1 h1:zEMLInw9xvNakzUUPjfS4Ds6jYPqCFx3m7bRmG5NH2U=
-bou.ke/monkey v1.0.1/go.mod h1:FgHuK96Rv2Nlf+0u1OOVDpCMdsWyOFmeeketDHE7LIg=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/QuarkChain/goqkcclient v0.0.0-20191220040322-0b8ed7eb66e8 h1:3B+Zwlj6yOeL+Ydhlzvben8sdrJqaHK5ywo7qzUbUFs=
@@ -22,7 +20,6 @@ github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtE
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -136,19 +133,15 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEha
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-golang.org/x/tools v0.0.0-20190114222345-bf090417da8b h1:qMK98NmNCRVDIYFycQ5yVRkvgDUFfdP8Ip4KqmDEB7g=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
@@ -170,12 +163,9 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkep
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/urfave/cli.v1 v1.20.0 h1:NdAVW6RYxDif9DhDHaAortIu956m2c0v+09AZBPTbE0=
 gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=
-gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-rsc.io/quote/v3 v3.1.0 h1:9JKUTTIUgS6kzR9mK1YuGKv6Nl+DijDNIc0ghT58FaY=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
-rsc.io/sampler v1.3.0 h1:7uVkIFmeBqHfdjD+gZwtXXI+RODJ2Wc4O7MPEh/QiW4=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=


### PR DESCRIPTION
## TL;DR

`go test ./core/` (and `./cluster/master/`) **panics on macOS** because the tests use `bou.ke/monkey`, which cannot patch code on macOS. This PR removes `bou.ke/monkey` in favor of a standard Go test seam. **Same test behavior, works on every OS, one less dependency, zero downsides.**

## Issue

On macOS the test run aborts:

```
--- FAIL: TestNativeTokenGas (0.00s)
panic: permission denied [recovered, repanicked]
...
bou.ke/monkey.copyToLocation(...)
        bou.ke/monkey@v1.0.1/replace_unix.go:18
```

**Environment:** Go 1.25.3, darwin/amd64.

## Root cause

`bou.ke/monkey` implements `monkey.Patch` by **rewriting the target function's machine code in place**, which requires making the code page writable *and* executable:

```go
syscall.Mprotect(page, PROT_READ|PROT_WRITE|PROT_EXEC)  // replace_unix.go:18 -> EACCES
```

macOS enforces **W^X** (a page is writable *or* executable, never both), so `mprotect` returns `EACCES` → panic. This is an OS-level restriction with no workaround in any `bou.ke/monkey` version (worse on Apple Silicon), and the library is unmaintained. Linux CI is unaffected because Linux allows W+X on code pages.

## Fix

Use a conventional Go test seam instead of machine-code patching. The four functions the tests stub become package-level `var` function values:

- `PayNativeTokenAsGas`, `GetGasUtilityInfo` (`core/state_processor.go`)
- `NewSlaveConn` (`cluster/master/slave_connection.go`)
- `createDB` (`cluster/master/backend.go`)

Tests then reassign + restore them instead of `monkey.Patch(...)`:

```go
// core: shared helper, restores via t.Cleanup
func stubNativeTokenGas(t *testing.T) {
    origPay, origInfo := PayNativeTokenAsGas, GetGasUtilityInfo
    t.Cleanup(func() { PayNativeTokenAsGas = origPay; GetGasUtilityInfo = origInfo })
    PayNativeTokenAsGas = func(...) (uint8, *big.Int, error) { return 100, gasPrice, nil }
    GetGasUtilityInfo  = func(...) (uint8, *big.Int, error) { return 100, gasPrice, nil }
}
```

The `cluster/master` test keeps its original scoping exactly (stubs active only during backend construction, restored via `defer`). The `bou.ke/monkey` dependency is removed from `go.mod`/`go.sum` (`memsize` is intentionally untouched here).

## Benefits

- ✅ Tests run on **macOS** (Intel + Apple Silicon) — previously impossible.
- ✅ Still run on **Linux/CI** exactly as before, and more robustly (no fragile machine-code rewriting, no `-gcflags=-l` inlining constraints).
- ✅ **Identical test behavior** — stubs return the same values; production call sites are unchanged.
- ✅ Drops an **unmaintained dependency** (`bou.ke/monkey`).

## Downsides

None. The functions become indirect calls (one pointer hop, negligible). The only shared-global caveat — reassigning a package-level var isn't safe under `t.Parallel()` — was already true of `monkey.Patch` (also global); these tests run serially, so behavior is unchanged.

## Test results (go1.25.3 on darwin/amd64 + go1.24.9 on Ubuntu 24.04)

```
ok  github.com/QuarkChain/goquarkchain/core
ok  github.com/QuarkChain/goquarkchain/cluster/master

--- PASS: TestNativeTokenGas
--- PASS: TestXshardNativeTokenGasSent
--- PASS: TestGasPrice
--- PASS: TestMasterBackend_InitCluster
--- PASS: TestMasterBackend_HeartBeat
```

Both packages fully pass; the three tests that previously panicked on macOS now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)