### PR TITLE
fix: separate block body and commit marker status

### DIFF
--- a/cluster/shard/api_backend.go
+++ b/cluster/shard/api_backend.go
@@ -24,6 +24,7 @@ import (
 var (
 	EmptyErrTemplate                 = "empty result when call %s, params: %v\n"
 	AllowedFutureBlocksTimeBroadcast = 15
+	ErrBodyDeleted                   = errors.New("block body deleted before commit")
 )
 
 // Wrapper over master connection, used by synchronizer.
@@ -305,14 +306,20 @@ func (s *ShardBackend) NewMinorBlock(peerId string, block *types.MinorBlock) (er
 	if s.mBPool.getBlockInPool(mHash) {
 		return
 	}
-	if s.MinorBlockChain.HasBlock(block.Hash()) {
+	if s.MinorBlockChain.HasCommittedBlock(block.Hash()) {
 		log.Debug("add minor block, Known minor block", "branch", block.Branch(), "height", block.Number())
 		return
 	}
 
-	if !s.MinorBlockChain.HasBlock(block.ParentHash()) {
-		log.Debug("prarent block hash not be included", "parent hash: ", block.ParentHash().Hex())
-		return
+	if !s.MinorBlockChain.HasCommittedBlock(block.ParentHash()) {
+		if err := s.commitUncommittedAncestorsIfPresent(block.ParentHash()); err != nil {
+			log.Warn(s.logInfo+" failed to commit uncommitted ancestors", "parent", block.ParentHash().Hex(), "err", err)
+			return nil
+		}
+		if !s.MinorBlockChain.HasCommittedBlock(block.ParentHash()) {
+			log.Debug("prarent block hash not be included", "parent hash: ", block.ParentHash().Hex())
+			return
+		}
 	}
 
 	//Sanity check on timestamp and block height
@@ -334,7 +341,7 @@ func (s *ShardBackend) NewMinorBlock(peerId string, block *types.MinorBlock) (er
 		return nil
 	}
 
-	if err := s.MinorBlockChain.Validator().ValidateBlock(block, false); err != nil {
+	if err := s.MinorBlockChain.Validator().ValidateBlock(block, true); err != nil {
 		log.Warn(s.logInfo+" ValidateBlock", "err", err)
 		return nil // next time to handle
 	}
@@ -355,17 +362,22 @@ func (s *ShardBackend) AddMinorBlock(block *types.MinorBlock) error {
 	log.Debug(s.logInfo+" AddMinorBlock", "height", block.NumberU64(), "hash", block.Hash().String())
 	defer log.Debug(s.logInfo+" AddMinorBlock end", "height", block.NumberU64())
 
+	blockHash := block.Hash()
+	if s.getBlockCommitStatusByHash(blockHash) == BLOCK_COMMITTED {
+		return nil
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.wg.Add(1)
 	defer s.wg.Done()
-	if commitStatus := s.getBlockCommitStatusByHash(block.Hash()); commitStatus == BLOCK_COMMITTED {
+	if s.getBlockCommitStatusByHash(blockHash) == BLOCK_COMMITTED {
 		return nil
 	}
-	//TODO support BLOCK_COMMITTING
 	currHead := s.MinorBlockChain.CurrentBlock().Header()
 	log.Debug(s.logInfo, "currHead", currHead.Number)
-	_, xshardLst, err := s.MinorBlockChain.InsertChainForDeposits([]types.IBlock{block}, false)
+	forceReplay := s.MinorBlockChain.HasBlockAndState(blockHash)
+	_, xshardLst, err := s.MinorBlockChain.InsertChainForDeposits([]types.IBlock{block}, forceReplay)
 	if err != nil {
 		log.Error(s.logInfo+" Failed to add minor block", "err", err, "len", len(xshardLst))
 		return err
@@ -378,10 +390,14 @@ func (s *ShardBackend) AddMinorBlock(block *types.MinorBlock) error {
 
 	// only remove from pool if the block successfully added to state,
 	// this may cache failed blocks but prevents them being broadcasted more than needed
-	s.mBPool.delBlockInPool(block.Hash())
+	s.mBPool.delBlockInPool(blockHash)
 
 	if xshardLst[0] == nil {
 		log.Info(s.logInfo+" add minor block has been added...", "branch", s.branch.Value, "height", block.Number())
+		if !s.MinorBlockChain.CommitMinorBlockByHash(blockHash) {
+			log.Warn(s.logInfo+" block body removed, cancelling commit", "hash", blockHash.Hex())
+			return fmt.Errorf("%w: %s", ErrBodyDeleted, blockHash.Hex())
+		}
 		return nil
 	}
 
@@ -408,7 +424,10 @@ func (s *ShardBackend) AddMinorBlock(block *types.MinorBlock) error {
 		s.setHead(currHead.Number)
 		return err
 	}
-	s.MinorBlockChain.CommitMinorBlockByHash(block.Hash())
+	if !s.MinorBlockChain.CommitMinorBlockByHash(blockHash) {
+		log.Warn(s.logInfo+" block body removed, cancelling commit", "hash", blockHash.Hex())
+		return fmt.Errorf("%w: %s", ErrBodyDeleted, blockHash.Hex())
+	}
 	if s.MinorBlockChain.CurrentBlock().Hash() != currHead.Hash() {
 		go s.miner.HandleNewTip()
 	}
@@ -420,6 +439,30 @@ func (s *ShardBackend) AddMinorBlock(block *types.MinorBlock) error {
 		}
 	}
 
+	return nil
+}
+
+func (s *ShardBackend) commitUncommittedAncestorsIfPresent(hash common.Hash) error {
+	blocks := make([]*types.MinorBlock, 0)
+	for !s.MinorBlockChain.HasCommittedBlock(hash) && s.MinorBlockChain.HasBlockAndState(hash) {
+		block := s.MinorBlockChain.GetMinorBlock(hash)
+		if block == nil {
+			return nil
+		}
+		blocks = append(blocks, block)
+		hash = block.ParentHash()
+	}
+	if len(blocks) == 0 || !s.MinorBlockChain.HasCommittedBlock(hash) {
+		return nil
+	}
+	for i := len(blocks) - 1; i >= 0; i-- {
+		if err := s.AddMinorBlock(blocks[i]); err != nil {
+			return err
+		}
+		if !s.MinorBlockChain.HasCommittedBlock(blocks[i].Hash()) {
+			return fmt.Errorf("failed to commit ancestor block: %s", blocks[i].Hash().Hex())
+		}
+	}
 	return nil
 }
 
@@ -451,8 +494,8 @@ func (s *ShardBackend) AddBlockListForSync(blockLst []*types.MinorBlock) error {
 		if s.getBlockCommitStatusByHash(blockHash) == BLOCK_COMMITTED {
 			continue
 		}
-		//TODO:support BLOCK_COMMITTING
-		_, xshardLst, err := s.MinorBlockChain.InsertChainForDeposits([]types.IBlock{block}, false)
+		forceReplay := s.MinorBlockChain.HasBlockAndState(blockHash)
+		_, xshardLst, err := s.MinorBlockChain.InsertChainForDeposits([]types.IBlock{block}, forceReplay)
 		if err != nil {
 			log.Error(s.logInfo+" Failed to add minor block", "err", err)
 			return err
@@ -478,8 +521,12 @@ func (s *ShardBackend) AddBlockListForSync(blockLst []*types.MinorBlock) error {
 		return err
 	}
 	for _, header := range uncommittedBlockHeaderList {
-		s.MinorBlockChain.CommitMinorBlockByHash(header.Hash())
-		s.mBPool.delBlockInPool(header.Hash())
+		blockHash := header.Hash()
+		if !s.MinorBlockChain.CommitMinorBlockByHash(blockHash) {
+			log.Warn(s.logInfo+" block body removed, cancelling commit", "hash", blockHash.Hex())
+			return fmt.Errorf("%w: %s", ErrBodyDeleted, blockHash.Hex())
+		}
+		s.mBPool.delBlockInPool(blockHash)
 	}
 	return nil
 }

--- a/cluster/shard/api_backend.go
+++ b/cluster/shard/api_backend.go
@@ -25,6 +25,7 @@ var (
 	EmptyErrTemplate                 = "empty result when call %s, params: %v\n"
 	AllowedFutureBlocksTimeBroadcast = 15
 	ErrBodyDeleted                   = errors.New("block body deleted before commit")
+	errParentBlockNotCommitted       = errors.New("parent block is not committed")
 )
 
 // Wrapper over master connection, used by synchronizer.
@@ -374,6 +375,9 @@ func (s *ShardBackend) AddMinorBlock(block *types.MinorBlock) error {
 	if s.getBlockCommitStatusByHash(blockHash) == BLOCK_COMMITTED {
 		return nil
 	}
+	if !s.MinorBlockChain.HasCommittedBlock(block.ParentHash()) {
+		return fmt.Errorf("%w: %s", errParentBlockNotCommitted, block.ParentHash().Hex())
+	}
 	currHead := s.MinorBlockChain.CurrentBlock().Header()
 	log.Debug(s.logInfo, "currHead", currHead.Number)
 	forceReplay := s.MinorBlockChain.HasBlockAndState(blockHash)
@@ -470,8 +474,7 @@ func (s *ShardBackend) commitUncommittedAncestorsIfPresent(hash common.Hash) err
 //
 // Returns true if blocks are successfully added. False on any error.
 // This function only adds blocks to local and propagate xshard list to other shards.
-// It does NOT notify master because the master should already have the minor header list,
-// and will add them once this function returns successfully.
+// It reports headers to master once as a batch.
 func (s *ShardBackend) AddBlockListForSync(blockLst []*types.MinorBlock) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -481,6 +484,21 @@ func (s *ShardBackend) AddBlockListForSync(blockLst []*types.MinorBlock) error {
 	if len(blockLst) == 0 {
 		return nil
 	}
+	for i, block := range blockLst {
+		if block.Branch().Value != s.branch.Value {
+			return fmt.Errorf("sync block list contains branch %d at index %d, want %d", block.Branch().Value, i, s.branch.Value)
+		}
+		if i > 0 && (block.NumberU64() != blockLst[i-1].NumberU64()+1 || block.ParentHash() != blockLst[i-1].Hash()) {
+			return fmt.Errorf("sync block list is not parent-first contiguous at index %d", i)
+		}
+	}
+	// The slave removes committed blocks before calling this method. Since
+	// commits are parent-first, that can only remove a committed prefix. After
+	// verifying the remaining list is contiguous, its first parent therefore
+	// establishes the commit boundary for the entire batch.
+	if !s.MinorBlockChain.HasCommittedBlock(blockLst[0].ParentHash()) {
+		return fmt.Errorf("%w: %s", errParentBlockNotCommitted, blockLst[0].ParentHash().Hex())
+	}
 
 	var (
 		blockHashToXShardList      = make(map[common.Hash]*XshardListTuple)
@@ -488,9 +506,6 @@ func (s *ShardBackend) AddBlockListForSync(blockLst []*types.MinorBlock) error {
 	)
 	for _, block := range blockLst {
 		blockHash := block.Hash()
-		if block.Branch().Value != s.branch.Value {
-			continue
-		}
 		if s.getBlockCommitStatusByHash(blockHash) == BLOCK_COMMITTED {
 			continue
 		}

--- a/cluster/shard/api_backend_race_test.go
+++ b/cluster/shard/api_backend_race_test.go
@@ -1,0 +1,81 @@
+//go:build race
+// +build race
+
+package shard
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/QuarkChain/goquarkchain/core/rawdb"
+	"github.com/QuarkChain/goquarkchain/core/types"
+)
+
+const raceIterations = 100
+
+func TestAddBlockListForSyncMarkerBodyConsistencyUnderRace(t *testing.T) {
+	for i := 0; i < raceIterations; i++ {
+		sb, db, stop := newTestShardBackend(t)
+
+		genesis := sb.MinorBlockChain.CurrentBlock()
+		block := makeTestMinorBlocks(t, db, genesis, 1)[0]
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = sb.AddBlockListForSync([]*types.MinorBlock{block})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = sb.MinorBlockChain.SetHead(genesis.NumberU64())
+		}()
+		wg.Wait()
+
+		hasBody := rawdb.HasBlock(db, block.Hash())
+		hasMarker := rawdb.HasCommitMinorBlock(db, block.Hash())
+		stop()
+
+		if hasMarker && !hasBody {
+			t.Fatalf("iter %d: commit marker present but block body absent", i)
+		}
+	}
+}
+
+func TestAddMinorBlockMarkerBodyConsistencyUnderRace(t *testing.T) {
+	for i := 0; i < raceIterations; i++ {
+		sb, db, stop := newTestShardBackend(t)
+
+		genesis := sb.MinorBlockChain.CurrentBlock()
+		blockA := makeTestMinorBlocks(t, db, genesis, 1)[0]
+		if _, err := sb.MinorBlockChain.InsertChain([]types.IBlock{blockA}, false); err != nil {
+			stop()
+			t.Fatalf("iter %d: pre-insert blockA: %v", i, err)
+		}
+		if !sb.MinorBlockChain.CommitMinorBlockByHash(blockA.Hash()) {
+			stop()
+			t.Fatalf("iter %d: pre-commit blockA failed", i)
+		}
+
+		blockAFork := makeTestForkBlock(t, db, genesis)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = sb.AddMinorBlock(blockAFork)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = sb.MinorBlockChain.SetHead(genesis.NumberU64())
+		}()
+		wg.Wait()
+
+		hasBody := rawdb.HasBlock(db, blockAFork.Hash())
+		hasMarker := rawdb.HasCommitMinorBlock(db, blockAFork.Hash())
+		stop()
+
+		if hasMarker && !hasBody {
+			t.Fatalf("iter %d: commit marker present but block body absent", i)
+		}
+	}
+}

--- a/cluster/shard/api_backend_test.go
+++ b/cluster/shard/api_backend_test.go
@@ -1,0 +1,239 @@
+package shard
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/QuarkChain/goquarkchain/account"
+	"github.com/QuarkChain/goquarkchain/cluster/config"
+	"github.com/QuarkChain/goquarkchain/cluster/miner"
+	"github.com/QuarkChain/goquarkchain/cluster/rpc"
+	"github.com/QuarkChain/goquarkchain/consensus"
+	"github.com/QuarkChain/goquarkchain/core"
+	"github.com/QuarkChain/goquarkchain/core/rawdb"
+	"github.com/QuarkChain/goquarkchain/core/types"
+	"github.com/QuarkChain/goquarkchain/core/vm"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+type stubConnManager struct{}
+
+func (s *stubConnManager) BroadcastXshardTxList(_ *types.MinorBlock, _ []*types.CrossShardTransactionDeposit, _ uint32) error {
+	return nil
+}
+
+func (s *stubConnManager) SendMinorBlockHeaderToMaster(_ *rpc.AddMinorBlockHeaderRequest) error {
+	return nil
+}
+
+func (s *stubConnManager) SendMinorBlockHeaderListToMaster(_ *rpc.AddMinorBlockHeaderListRequest) error {
+	return nil
+}
+
+func (s *stubConnManager) BatchBroadcastXshardTxList(_ map[common.Hash]*XshardListTuple, _ account.Branch) error {
+	return nil
+}
+
+func (s *stubConnManager) BroadcastNewTip(_ []*types.MinorBlockHeader, _ *types.RootBlockHeader, _ uint32) error {
+	return nil
+}
+
+func (s *stubConnManager) BroadcastTransactions(_ string, _ uint32, _ []*types.Transaction) error {
+	return nil
+}
+
+func (s *stubConnManager) BroadcastMinorBlock(_ string, _ *types.MinorBlock) error {
+	return nil
+}
+
+func (s *stubConnManager) GetMinorBlocks(_ []common.Hash, _ string, _ uint32) ([]*types.MinorBlock, error) {
+	return nil, nil
+}
+
+func (s *stubConnManager) GetMinorBlockHeaderList(_ *rpc.GetMinorBlockHeaderListWithSkipRequest) ([]*types.MinorBlockHeader, error) {
+	return nil, nil
+}
+
+type stubMinerAPI struct{}
+
+func (s *stubMinerAPI) GetDefaultCoinbaseAddress() account.Address {
+	return account.CreatEmptyAddress(0)
+}
+
+func (s *stubMinerAPI) CreateBlockToMine(_ *account.Address) (types.IBlock, *big.Int, uint64, error) {
+	return nil, nil, 0, errors.New("stub miner does not create blocks")
+}
+
+func (s *stubMinerAPI) InsertMinedBlock(types.IBlock) error {
+	return nil
+}
+
+func (s *stubMinerAPI) IsSyncing() bool {
+	return true
+}
+
+func (s *stubMinerAPI) GetTip() uint64 {
+	return 0
+}
+
+func newTestShardBackend(t *testing.T) (*ShardBackend, ethdb.Database, func()) {
+	t.Helper()
+
+	clusterCfg := config.NewClusterConfig()
+	clusterCfg.Quarkchain.SkipMinorDifficultyCheck = true
+	clusterCfg.Quarkchain.SkipRootDifficultyCheck = true
+	clusterCfg.Quarkchain.SkipRootCoinbaseCheck = true
+	fullShardID := clusterCfg.Quarkchain.Chains[0].ShardSize | 0
+
+	db := ethdb.NewMemDatabase()
+	gspec := core.NewGenesis(clusterCfg.Quarkchain)
+	rootBlock := gspec.CreateRootBlock()
+	gspec.MustCommitMinorBlock(db, rootBlock, fullShardID)
+
+	blockchain, err := core.NewMinorBlockChain(db, nil, params.TestChainConfig, clusterCfg, new(consensus.FakeEngine), vm.Config{}, nil, fullShardID)
+	if err != nil {
+		t.Fatalf("NewMinorBlockChain: %v", err)
+	}
+	if _, err := blockchain.InitGenesisState(rootBlock); err != nil {
+		t.Fatalf("InitGenesisState: %v", err)
+	}
+
+	testMiner := miner.New(nil, &stubMinerAPI{}, new(consensus.FakeEngine))
+	sb := &ShardBackend{
+		branch:          account.Branch{Value: fullShardID},
+		MinorBlockChain: blockchain,
+		conn:            &stubConnManager{},
+		mBPool:          newBlockPool{BlockPool: make(map[common.Hash]bool)},
+		logInfo:         "test-shard",
+		miner:           testMiner,
+	}
+	return sb, db, func() {
+		testMiner.Stop()
+		blockchain.Stop()
+	}
+}
+
+func minorBlocksToIBlocks(blocks []*types.MinorBlock) []types.IBlock {
+	result := make([]types.IBlock, len(blocks))
+	for i, block := range blocks {
+		result[i] = block
+	}
+	return result
+}
+
+func makeTestMinorBlocks(t *testing.T, db ethdb.Database, parent *types.MinorBlock, n int) []*types.MinorBlock {
+	t.Helper()
+	blocks, _ := core.GenerateMinorBlockChain(params.TestChainConfig, config.NewQuarkChainConfig(), parent, new(consensus.FakeEngine), db, n, nil)
+	return blocks
+}
+
+func makeTestForkBlock(t *testing.T, db ethdb.Database, parent *types.MinorBlock) *types.MinorBlock {
+	t.Helper()
+	blocks, _ := core.GenerateMinorBlockChain(
+		params.TestChainConfig,
+		config.NewQuarkChainConfig(),
+		parent,
+		new(consensus.FakeEngine),
+		db,
+		1,
+		func(_ *config.QuarkChainConfig, _ int, b *core.MinorBlockGen) {
+			b.SetCoinbase(account.Address{Recipient: account.Recipient{0: 0xAB}, FullShardKey: 0})
+		},
+	)
+	return blocks[0]
+}
+
+func TestAddBlockListForSyncSkipsCommittedBlockAndCommitsRest(t *testing.T) {
+	sb, db, stop := newTestShardBackend(t)
+	defer stop()
+
+	blocks := makeTestMinorBlocks(t, db, sb.MinorBlockChain.CurrentBlock(), 2)
+	blockA, blockB := blocks[0], blocks[1]
+	if _, err := sb.MinorBlockChain.InsertChain(minorBlocksToIBlocks(blocks[:1]), false); err != nil {
+		t.Fatalf("pre-insert blockA: %v", err)
+	}
+	if !sb.MinorBlockChain.CommitMinorBlockByHash(blockA.Hash()) {
+		t.Fatal("blockA should commit after its body is inserted")
+	}
+
+	if err := sb.AddBlockListForSync([]*types.MinorBlock{blockA, blockB}); err != nil {
+		t.Fatalf("AddBlockListForSync: %v", err)
+	}
+	if !sb.MinorBlockChain.HasCommittedBlock(blockA.Hash()) {
+		t.Fatal("blockA should remain committed")
+	}
+	if !sb.MinorBlockChain.HasCommittedBlock(blockB.Hash()) {
+		t.Fatal("blockB should be processed and committed after committed blockA is skipped")
+	}
+	if sb.MinorBlockChain.CurrentBlock().Hash() != blockB.Hash() {
+		t.Fatalf("chain tip should be blockB, got %s", sb.MinorBlockChain.CurrentBlock().Hash().Hex())
+	}
+}
+
+func TestAddMinorBlockWritesCommitMarker(t *testing.T) {
+	sb, db, stop := newTestShardBackend(t)
+	defer stop()
+
+	genesis := sb.MinorBlockChain.CurrentBlock()
+	blockA := makeTestMinorBlocks(t, db, genesis, 1)[0]
+	if _, err := sb.MinorBlockChain.InsertChain([]types.IBlock{blockA}, false); err != nil {
+		t.Fatalf("pre-insert blockA: %v", err)
+	}
+
+	blockAFork := makeTestForkBlock(t, db, genesis)
+	if err := sb.AddMinorBlock(blockAFork); err != nil {
+		t.Fatalf("AddMinorBlock: %v", err)
+	}
+	if !rawdb.HasBlock(db, blockAFork.Hash()) {
+		t.Fatal("fork block body should be present after AddMinorBlock")
+	}
+	if !rawdb.HasCommitMinorBlock(db, blockAFork.Hash()) {
+		t.Fatal("fork block commit marker should be written by AddMinorBlock")
+	}
+}
+
+func TestAddBlockListForSyncRecoversUncommittedBody(t *testing.T) {
+	sb, db, stop := newTestShardBackend(t)
+	defer stop()
+
+	block := makeTestMinorBlocks(t, db, sb.MinorBlockChain.CurrentBlock(), 1)[0]
+	if _, err := sb.MinorBlockChain.InsertChain([]types.IBlock{block}, false); err != nil {
+		t.Fatalf("pre-insert body: %v", err)
+	}
+	if !rawdb.HasBlock(db, block.Hash()) {
+		t.Fatal("block body should be present after InsertChain")
+	}
+	if rawdb.HasCommitMinorBlock(db, block.Hash()) {
+		t.Fatal("commit marker should be absent after core InsertChain")
+	}
+
+	if err := sb.AddBlockListForSync([]*types.MinorBlock{block}); err != nil {
+		t.Fatalf("AddBlockListForSync retry: %v", err)
+	}
+	if !sb.MinorBlockChain.HasCommittedBlock(block.Hash()) {
+		t.Fatal("retry should commit existing body")
+	}
+}
+
+func TestNewMinorBlockRecoversUncommittedBody(t *testing.T) {
+	sb, db, stop := newTestShardBackend(t)
+	defer stop()
+
+	block := makeTestMinorBlocks(t, db, sb.MinorBlockChain.CurrentBlock(), 1)[0]
+	if _, err := sb.MinorBlockChain.InsertChain([]types.IBlock{block}, false); err != nil {
+		t.Fatalf("pre-insert body: %v", err)
+	}
+	if rawdb.HasCommitMinorBlock(db, block.Hash()) {
+		t.Fatal("commit marker should be absent after core InsertChain")
+	}
+
+	if err := sb.NewMinorBlock("peer-1", block); err != nil {
+		t.Fatalf("NewMinorBlock retry: %v", err)
+	}
+	if !sb.MinorBlockChain.HasCommittedBlock(block.Hash()) {
+		t.Fatal("NewMinorBlock should route existing uncommitted body through AddMinorBlock")
+	}
+}

--- a/cluster/shard/api_backend_test.go
+++ b/cluster/shard/api_backend_test.go
@@ -171,6 +171,9 @@ func TestAddBlockListForSyncSkipsCommittedBlockAndCommitsRest(t *testing.T) {
 	if sb.MinorBlockChain.CurrentBlock().Hash() != blockB.Hash() {
 		t.Fatalf("chain tip should be blockB, got %s", sb.MinorBlockChain.CurrentBlock().Hash().Hex())
 	}
+	if err := sb.AddBlockListForSync([]*types.MinorBlock{blockB, blockA}); err == nil {
+		t.Fatal("out-of-order sync list should be rejected")
+	}
 }
 
 func TestAddMinorBlockWritesCommitMarker(t *testing.T) {
@@ -192,6 +195,11 @@ func TestAddMinorBlockWritesCommitMarker(t *testing.T) {
 	}
 	if !rawdb.HasCommitMinorBlock(db, blockAFork.Hash()) {
 		t.Fatal("fork block commit marker should be written by AddMinorBlock")
+	}
+
+	child := makeTestMinorBlocks(t, db, blockA, 1)[0]
+	if err := sb.AddMinorBlock(child); !errors.Is(err, errParentBlockNotCommitted) {
+		t.Fatalf("AddMinorBlock error = %v, want %v", err, errParentBlockNotCommitted)
 	}
 }
 
@@ -215,6 +223,18 @@ func TestAddBlockListForSyncRecoversUncommittedBody(t *testing.T) {
 	}
 	if !sb.MinorBlockChain.HasCommittedBlock(block.Hash()) {
 		t.Fatal("retry should commit existing body")
+	}
+
+	blocks := makeTestMinorBlocks(t, db, block, 2)
+	parent, child := blocks[0], blocks[1]
+	if _, err := sb.MinorBlockChain.InsertChain([]types.IBlock{parent}, false); err != nil {
+		t.Fatalf("pre-insert uncommitted parent: %v", err)
+	}
+	if err := sb.AddBlockListForSync([]*types.MinorBlock{child}); !errors.Is(err, errParentBlockNotCommitted) {
+		t.Fatalf("AddBlockListForSync error = %v, want %v", err, errParentBlockNotCommitted)
+	}
+	if sb.MinorBlockChain.HasCommittedBlock(child.Hash()) {
+		t.Fatal("rejected child should not be committed")
 	}
 }
 

--- a/cluster/shard/shard.go
+++ b/cluster/shard/shard.go
@@ -32,7 +32,6 @@ type BlockCommitCode int
 
 const (
 	BLOCK_UNCOMMITTED BlockCommitCode = iota
-	BLOCK_COMMITTING                  // TODO not support yet,need discuss
 	BLOCK_COMMITTED
 )
 
@@ -207,18 +206,9 @@ func (s *ShardBackend) initGenesisState(rootBlock *types.RootBlock) error {
 }
 
 func (s *ShardBackend) getBlockCommitStatusByHash(blockHash common.Hash) BlockCommitCode {
-	// If the block is committed, it means
-	// - All neighbor shards/slaves receives x-shard tx list
-	// - The block header is sent to master
-	// then return immediately
-	if s.MinorBlockChain.IsMinorBlockCommittedByHash(blockHash) {
+	if s.MinorBlockChain.HasCommittedBlock(blockHash) {
 		return BLOCK_COMMITTED
 	}
-
-	//TODO support BLOCK_COMMITTING???
-
-	// Check if the block is being propagating to other slaves and the master
-	// Let's make sure all the shards and master got it before committing it
 	return BLOCK_UNCOMMITTED
 }
 

--- a/cluster/slave/api_backend.go
+++ b/cluster/slave/api_backend.go
@@ -98,9 +98,11 @@ func (s *SlaveBackend) AddBlockListForSync(mHashList []common.Hash, peerId strin
 
 	hashList := make([]common.Hash, 0, len(mHashList))
 	for _, hash := range mHashList {
-		if !shard.MinorBlockChain.HasBlock(hash) {
-			hashList = append(hashList, hash)
+		if shard.MinorBlockChain.HasCommittedBlock(hash) {
+			continue
 		}
+
+		hashList = append(hashList, hash)
 	}
 
 	var (

--- a/cluster/sync/minor_task.go
+++ b/cluster/sync/minor_task.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	
+
 	"github.com/QuarkChain/goquarkchain/account"
 	"github.com/QuarkChain/goquarkchain/cluster/rpc"
 	qcom "github.com/QuarkChain/goquarkchain/common"
@@ -44,21 +44,11 @@ func NewMinorChainTask(
 		maxSyncStaleness: 22500 * 6, // TODO: derive from root chain?
 		batchSize:        MinorBlockHeaderListLimit,
 		findAncestor: func(bc blockchain) (types.IHeader, error) {
-
-			if bc.HasBlock(mTask.header.Hash()) {
-				return nil, nil
-			}
-
 			ancestor, err := mTask.findAncestor(bc)
 			if err != nil {
 				mTask.stats.AncestorNotFoundCount += 1
 				return nil, err
 			}
-
-			if !bc.HasBlock(ancestor.Hash()) {
-				return nil, errors.New("Bad ancestor ")
-			}
-
 			return ancestor, nil
 		},
 		getHeaders: func(startheader types.IHeader) ([]types.IHeader, error) {
@@ -104,7 +94,10 @@ func NewMinorChainTask(
 			return ret, nil
 		},
 		needSkip: func(b blockchain) bool {
-			if mTask.header.NumberU64() <= b.CurrentHeader().NumberU64() || b.HasBlock(mTask.header.Hash()) {
+			tip := b.CurrentHeader()
+			if mTask.header.NumberU64() < tip.NumberU64() ||
+				(mTask.header.NumberU64() == tip.NumberU64() && b.HasCommittedBlock(tip.Hash())) ||
+				b.HasCommittedBlock(mTask.header.Hash()) {
 				return true
 			}
 
@@ -175,8 +168,12 @@ func (m *minorChainTask) downloadBlockHeaderListAndCheck(height, skip, limit uin
 }
 
 func (m *minorChainTask) findAncestor(bc blockchain) (*types.MinorBlockHeader, error) {
+	if bc.HasCommittedBlock(m.header.Hash()) {
+		return nil, nil
+	}
+
 	mtip := bc.CurrentHeader().(*types.MinorBlockHeader)
-	if m.header.Hash() == mtip.Hash() {
+	if m.header.Hash() == mtip.Hash() && bc.HasCommittedBlock(mtip.Hash()) {
 		return mtip, nil
 	}
 
@@ -210,7 +207,7 @@ func (m *minorChainTask) findAncestor(bc blockchain) (*types.MinorBlockHeader, e
 			}
 			preHeader = mh
 
-			if !bc.HasBlock(mh.Hash()) {
+			if !bc.HasCommittedBlock(mh.Hash()) {
 				end = mh.Number - 1
 				continue
 			}
@@ -225,6 +222,9 @@ func (m *minorChainTask) findAncestor(bc blockchain) (*types.MinorBlockHeader, e
 			}
 			break
 		}
+	}
+	if bestAncestor == nil {
+		return nil, errors.New("No common ancestor found for minor chain")
 	}
 	return bestAncestor, nil
 }

--- a/cluster/sync/minor_task_test.go
+++ b/cluster/sync/minor_task_test.go
@@ -111,6 +111,9 @@ func newMinorBlockChain(sz int) (blockchain, ethdb.Database) {
 	if _, err := mbc.InsertChain(blocks, false); err != nil {
 		panic(fmt.Sprintf("failed to insert minor blocks: %v", err))
 	}
+	for _, block := range blocks {
+		mbc.CommitMinorBlockByHash(block.Hash())
+	}
 
 	return &mockblockchain{mbc: mbc}, db
 }

--- a/cluster/sync/root_task.go
+++ b/cluster/sync/root_task.go
@@ -54,22 +54,12 @@ func NewRootChainTask(
 		// change the batch size to 3 for tps test
 		batchSize: 3, // RootBlockBatchSize,
 		findAncestor: func(bc blockchain) (types.IHeader, error) {
-
-			if bc.HasBlock(rTask.header.Hash()) {
-				return nil, nil
-			}
-
 			ancestor, err := rTask.findAncestor(bc)
 			if err != nil {
 				rTask.stats.AncestorNotFoundCount += 1
 				return nil, err
 			}
-
-			if !bc.HasBlock(ancestor.Hash()) {
-				return nil, errors.New("Bad ancestor ")
-			}
-
-			if rTask.header.ToTalDifficulty.Cmp(ancestor.ToTalDifficulty) < 0 {
+			if !qcom.IsNil(ancestor) && rTask.header.GetTotalDifficulty().Cmp(ancestor.GetTotalDifficulty()) < 0 {
 				return nil, errors.New("ancestor's total difficulty is bigger than current")
 			}
 			return ancestor, nil
@@ -177,6 +167,10 @@ func (r *rootChainTask) downloadBlockHeaderListAndCheck(start uint32, skip,
 }
 
 func (r *rootChainTask) findAncestor(bc blockchain) (*types.RootBlockHeader, error) {
+	if bc.HasCommittedBlock(r.header.Hash()) {
+		return nil, nil
+	}
+
 	rtip := bc.CurrentHeader().(*types.RootBlockHeader)
 	if r.header.ParentHash == rtip.Hash() {
 		return rtip, nil
@@ -213,7 +207,7 @@ func (r *rootChainTask) findAncestor(bc blockchain) (*types.RootBlockHeader, err
 			}
 			preHeader = rh
 
-			if !bc.HasBlock(rh.Hash()) {
+			if !bc.HasCommittedBlock(rh.Hash()) {
 				end = rh.Number - 1
 				continue
 			}
@@ -230,6 +224,10 @@ func (r *rootChainTask) findAncestor(bc blockchain) (*types.RootBlockHeader, err
 			break
 		}
 	}
+	if bestAncestor == nil {
+		return nil, errors.New("No common ancestor found for root chain")
+	}
+
 	return bestAncestor, nil
 }
 

--- a/cluster/sync/root_task_test.go
+++ b/cluster/sync/root_task_test.go
@@ -141,12 +141,22 @@ func (bc *mockblockchain) HasBlock(hash common.Hash) bool {
 
 }
 
+func (bc *mockblockchain) HasCommittedBlock(hash common.Hash) bool {
+	if bc.rbc != nil {
+		return bc.HasBlock(hash)
+	}
+	return bc.mbc.HasCommittedBlock(hash)
+}
+
 func (bc *mockblockchain) AddBlock(block types.IBlock) error {
 	if bc.rbc != nil {
 		_, err := bc.rbc.InsertChain([]types.IBlock{block})
 		return err
 	}
 	_, err := bc.mbc.InsertChain([]types.IBlock{block}, false)
+	if err == nil {
+		bc.mbc.CommitMinorBlockByHash(block.Hash())
+	}
 	return err
 }
 

--- a/cluster/sync/sync.go
+++ b/cluster/sync/sync.go
@@ -3,7 +3,7 @@ package sync
 import (
 	"math/big"
 	"sync"
-	
+
 	"github.com/QuarkChain/goquarkchain/core"
 	"github.com/QuarkChain/goquarkchain/core/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -14,6 +14,7 @@ import (
 // A lightweight wrapper over shard chain or root chain.
 type blockchain interface {
 	HasBlock(common.Hash) bool
+	HasCommittedBlock(common.Hash) bool
 	AddBlock(types.IBlock) error
 	CurrentHeader() types.IHeader
 	Validator() core.Validator

--- a/core/minorblockchain.go
+++ b/core/minorblockchain.go
@@ -553,9 +553,16 @@ func (m *MinorBlockChain) Genesis() *types.MinorBlock {
 	return m.genesisBlock
 }
 
-// HasBlock checks if a block is fully present in the database or not.
+// HasCommittedBlock reports whether the block body is present and the shard
+// layer has written the commit marker after x-shard/master side effects.
+func (m *MinorBlockChain) HasCommittedBlock(hash common.Hash) bool {
+	return rawdb.HasBlock(m.db, hash) && rawdb.HasCommitMinorBlock(m.db, hash)
+}
+
+// HasBlock checks if a block body is present in the database. It does not imply
+// that the shard-level commit marker has been written.
 func (m *MinorBlockChain) HasBlock(hash common.Hash) bool {
-	return m.IsMinorBlockCommittedByHash(hash)
+	return rawdb.HasBlock(m.db, hash)
 }
 
 // HasState checks if state trie is fully present in the database or not.
@@ -1006,7 +1013,6 @@ func (m *MinorBlockChain) WriteBlockWithState(block *types.MinorBlock, receipts 
 	if status == CanonStatTy {
 		m.insert(block)
 	}
-	m.CommitMinorBlockByHash(block.Hash())
 	m.futureBlocks.Remove(block.Hash())
 	return status, nil
 }
@@ -1175,6 +1181,11 @@ func (m *MinorBlockChain) insertChain(chain []types.IBlock, verifySeals bool, is
 			return it.index, events, coalescedLogs, xShardList, err
 		}
 
+		if isCheckDB && m.HasBlockAndState(mBlock.Hash()) {
+			xShardList = append(xShardList, state.GetXShardList())
+			continue
+		}
+
 		if isCheckDB {
 			xShardList = append(xShardList, state.GetXShardList())
 			return 0, events, coalescedLogs, xShardList, nil
@@ -1276,7 +1287,6 @@ func (m *MinorBlockChain) insertSidechain(it *insertIterator, isCheckDB bool) (i
 			if err := m.WriteBlockWithoutState(block); err != nil {
 				return it.index, nil, nil, nil, err
 			}
-			m.CommitMinorBlockByHash(block.Hash())
 			log.Debug("Inserted sidechain block", "number", block.NumberU64(), "hash", block.Hash(),
 				"diff", block.IHeader().GetDifficulty(), "elapsed", common.PrettyDuration(time.Since(start)),
 				"txs", len(block.(*types.MinorBlock).GetTransactions()), "gas", block.(*types.MinorBlock).GetMetaData().GasUsed,

--- a/core/minorblockchain.go
+++ b/core/minorblockchain.go
@@ -149,6 +149,7 @@ type MinorBlockChain struct {
 	heightToMBlockHashCount  map[uint64]int
 	currentEvmState          *state.StateDB
 	logInfo                  string
+	addMinorBlockMu          sync.RWMutex
 	addMinorBlockAndBroad    func(block *types.MinorBlock) error
 	posw                     consensus.PoSWCalculator
 	gasLimit                 *big.Int
@@ -254,7 +255,15 @@ func (m *MinorBlockChain) EthChainID() uint32 {
 }
 
 func (m *MinorBlockChain) SetBroadcastMinorBlockFunc(f func(block *types.MinorBlock) error) {
+	m.addMinorBlockMu.Lock()
+	defer m.addMinorBlockMu.Unlock()
 	m.addMinorBlockAndBroad = f
+}
+
+func (m *MinorBlockChain) getBroadcastMinorBlockFunc() func(block *types.MinorBlock) error {
+	m.addMinorBlockMu.RLock()
+	defer m.addMinorBlockMu.RUnlock()
+	return m.addMinorBlockAndBroad
 }
 
 func (m *MinorBlockChain) AddBlock(block types.IBlock) error {
@@ -262,7 +271,11 @@ func (m *MinorBlockChain) AddBlock(block types.IBlock) error {
 	if !ok {
 		return errors.New("block is not minorBlock")
 	}
-	return m.addMinorBlockAndBroad(minorBlock)
+	handler := m.getBroadcastMinorBlockFunc()
+	if handler == nil {
+		return errors.New("minor block handler is not configured")
+	}
+	return handler(minorBlock)
 }
 
 func (m *MinorBlockChain) getProcInterrupt() bool {
@@ -741,10 +754,18 @@ func (m *MinorBlockChain) procFutureBlocks() {
 		}
 	}
 	if len(blocks) > 0 {
+		handler := m.getBroadcastMinorBlockFunc()
+		if handler == nil {
+			log.Warn(m.logInfo + " future block handler is not configured")
+			return
+		}
 		sort.Slice(blocks, func(i, j int) bool { return blocks[i].NumberU64() < blocks[j].NumberU64() })
-		// Insert one by one as chain insertion needs contiguous ancestry between blocks
+		// Process one by one through the shard callback so broadcast/report/commit
+		// side effects run for blocks that mature out of the future-block queue.
 		for i := range blocks {
-			m.InsertChain(blocks[i:i+1], false)
+			if err := handler(blocks[i].(*types.MinorBlock)); err != nil {
+				log.Warn(m.logInfo+" failed to process future block", "number", blocks[i].NumberU64(), "hash", blocks[i].Hash(), "err", err)
+			}
 		}
 	}
 }

--- a/core/minorblockchain_addon.go
+++ b/core/minorblockchain_addon.go
@@ -350,7 +350,7 @@ func (m *MinorBlockChain) InitGenesisState(rBlock *types.RootBlock) (*types.Mino
 	}
 	m.putRootBlock(rBlock, nil)
 	rawdb.WriteGenesisBlock(m.db, rBlock.Hash(), gBlock) // key:rootBlockHash value:minorBlock
-	m.CommitMinorBlockByHash(gBlock.Hash())
+	rawdb.WriteCommitMinorBlock(m.db, gBlock.Hash())
 	if m.initialized {
 		return gBlock, nil
 	}
@@ -1882,8 +1882,17 @@ func (m *MinorBlockChain) IsMinorBlockCommittedByHash(h common.Hash) bool {
 	return rawdb.HasCommitMinorBlock(m.db, h)
 }
 
-func (m *MinorBlockChain) CommitMinorBlockByHash(h common.Hash) {
+// CommitMinorBlockByHash writes the commit marker only if the block body is
+// still present. A false return means the block remains uncommitted and should
+// be retried by sync.
+func (m *MinorBlockChain) CommitMinorBlockByHash(h common.Hash) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !rawdb.HasBlock(m.db, h) {
+		return false
+	}
 	rawdb.WriteCommitMinorBlock(m.db, h)
+	return true
 }
 
 func (m *MinorBlockChain) GetMiningInfo(address account.Recipient, stake *types.TokenBalances) (mineable, mined uint64, err error) {

--- a/core/minorblockchain_test.go
+++ b/core/minorblockchain_test.go
@@ -1400,5 +1400,47 @@ func TestVerifyHeaderTypedNilParentReturnsErrUnknownAncestor(t *testing.T) {
 	}
 }
 
+func TestCommitMinorBlockByHashRequiresBody(t *testing.T) {
+	db, blockchain, err := newMinorCanonical(nil, engine, 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer blockchain.Stop()
+
+	missingHash := common.HexToHash("0xdeadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678")
+	if blockchain.CommitMinorBlockByHash(missingHash) {
+		t.Fatal("commit marker should not be written when body is absent")
+	}
+	if rawdb.HasCommitMinorBlock(db, missingHash) {
+		t.Fatal("commit marker exists for missing body")
+	}
+}
+
+func TestInsertChainWritesBodyWithoutCommitMarker(t *testing.T) {
+	db, blockchain, err := newMinorCanonical(nil, engine, 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer blockchain.Stop()
+
+	blocks := makeBlockChain(blockchain.CurrentBlock(), 1, engine, db, canonicalSeed)
+	if _, err := blockchain.InsertChain(toMinorBlocks(blocks), false); err != nil {
+		t.Fatal(err)
+	}
+	block := blocks[0]
+	if !blockchain.HasBlock(block.Hash()) {
+		t.Fatal("body should be present after InsertChain")
+	}
+	if blockchain.HasCommittedBlock(block.Hash()) {
+		t.Fatal("InsertChain should not write the commit marker")
+	}
+	if !blockchain.CommitMinorBlockByHash(block.Hash()) {
+		t.Fatal("commit marker should be written when body is present")
+	}
+	if !blockchain.HasCommittedBlock(block.Hash()) {
+		t.Fatal("block should be committed after CommitMinorBlockByHash")
+	}
+}
+
 //TODO
 //Bench test: qkc genesis not support code set

--- a/core/minorblockchain_test.go
+++ b/core/minorblockchain_test.go
@@ -1460,5 +1460,30 @@ func TestInsertChainWritesBodyWithoutCommitMarker(t *testing.T) {
 	}
 }
 
+func TestProcFutureBlocksUsesShardCallback(t *testing.T) {
+	db, blockchain, err := newMinorCanonical(nil, engine, 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer blockchain.Stop()
+
+	block := makeBlockChain(blockchain.CurrentBlock(), 1, engine, db, canonicalSeed)[0]
+	called := 0
+	blockchain.SetBroadcastMinorBlockFunc(func(got *types.MinorBlock) error {
+		called++
+		if got.Hash() != block.Hash() {
+			t.Fatalf("callback block mismatch: got %s want %s", got.Hash(), block.Hash())
+		}
+		return nil
+	})
+	blockchain.futureBlocks.Add(block.Hash(), block)
+
+	blockchain.procFutureBlocks()
+
+	if called != 1 {
+		t.Fatalf("future block callback called %d times, want 1", called)
+	}
+}
+
 //TODO
 //Bench test: qkc genesis not support code set

--- a/core/minorblockchain_test.go
+++ b/core/minorblockchain_test.go
@@ -1416,6 +1416,24 @@ func TestCommitMinorBlockByHashRequiresBody(t *testing.T) {
 	}
 }
 
+func TestHasBlockFalseWhenBodyAbsentButMarkerPresent(t *testing.T) {
+	db, blockchain, err := newMinorCanonical(nil, engine, 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer blockchain.Stop()
+
+	missingHash := common.HexToHash("0xdeadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678")
+	rawdb.WriteCommitMinorBlock(db, missingHash)
+
+	if !rawdb.HasCommitMinorBlock(db, missingHash) {
+		t.Fatal("setup failed: commit marker should exist")
+	}
+	if blockchain.HasBlock(missingHash) {
+		t.Fatal("HasBlock should be false when only the commit marker exists")
+	}
+}
+
 func TestInsertChainWritesBodyWithoutCommitMarker(t *testing.T) {
 	db, blockchain, err := newMinorCanonical(nil, engine, 0, true)
 	if err != nil {

--- a/core/rootblockchain.go
+++ b/core/rootblockchain.go
@@ -344,6 +344,12 @@ func (bc *RootBlockChain) HasBlock(hash common.Hash) bool {
 	return rawdb.HasBlock(bc.db, hash)
 }
 
+// HasCommittedBlock satisfies the sync.blockchain interface. Root blocks do not
+// have a separate shard commit marker, so committed is equivalent to present.
+func (bc *RootBlockChain) HasCommittedBlock(hash common.Hash) bool {
+	return bc.HasBlock(hash)
+}
+
 // GetBlock retrieves a block from the database by hash and number,
 // caching it if found.
 func (bc *RootBlockChain) GetBlock(hash common.Hash) types.IBlock {
@@ -440,7 +446,7 @@ func (bc *RootBlockChain) WriteBlockWithoutState(block types.IBlock) (err error)
 	return nil
 }
 
-//todo
+// todo
 // WriteBlockWithState writes the block and all associated state to the database.
 func (bc *RootBlockChain) WriteBlockWithState(block *types.RootBlock) (status WriteStatus, err error) {
 	bc.wg.Add(1)
@@ -1059,7 +1065,7 @@ func (bc *RootBlockChain) SkipDifficultyCheck() bool {
 	return bc.Config().SkipRootDifficultyCheck
 }
 
-//For remote miner to getWork, no signature verified
+// For remote miner to getWork, no signature verified
 func (bc *RootBlockChain) GetAdjustedDifficultyToMine(header types.IHeader) (*big.Int, uint64, error) {
 	rHeader := header.(*types.RootBlockHeader)
 	if crypto.VerifySignature(bc.Config().GuardianPublicKey, rHeader.SealHash().Bytes(), rHeader.Signature[:64]) {

--- a/core/shardstate_test.go
+++ b/core/shardstate_test.go
@@ -2409,7 +2409,7 @@ func TestXShardFromRootBlock(t *testing.T) {
 	assert.Equal(t, 1000000, int(getDefaultBalance(acc2, state0).Uint64()))
 }
 
-//separate from test_xshard_from_root_block()
+// separate from test_xshard_from_root_block()
 func TestXShardFromRootBlockWithCoinbaseIsCode(t *testing.T) {
 	id1, err := account.CreatRandomIdentity()
 	checkErr(err)
@@ -2450,7 +2450,7 @@ func TestXShardFromRootBlockWithCoinbaseIsCode(t *testing.T) {
 	assert.Equal(t, 1000000, int(getDefaultBalance(contractAddress, state0).Uint64()))
 }
 
-//goquarkchain only
+// goquarkchain only
 func TestTransferToContract(t *testing.T) {
 	id1, err := account.CreatRandomIdentity()
 	checkErr(err)
@@ -3629,4 +3629,30 @@ func TestXshardGasLimitFromMultipleShards(t *testing.T) {
 	//	# Root block coinbase does not consume xshard gas
 	tb = shardState0.currentEvmState.GetBalance(acc1.Recipient, shardState0.GetGenesisToken())
 	assert.Equal(t, tb, big.NewInt(10000000+1000000+12345+888888+111111))
+}
+
+func TestInsertChainForDepositsForceMultiBlock(t *testing.T) {
+	env := setUp(nil, nil, nil)
+	shardState := createDefaultShardState(env, nil, nil, nil, nil)
+	defer shardState.Stop()
+
+	b1 := shardState.CurrentBlock().CreateBlockToAppend(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	b1, _, err := shardState.FinalizeAndAddBlock(b1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b2 := shardState.CurrentBlock().CreateBlockToAppend(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	b2, _, err = shardState.FinalizeAndAddBlock(b2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, xshardList, err := shardState.InsertChainForDeposits([]types.IBlock{b1, b2}, true)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(xshardList))
+
+	_, xshardList, err = shardState.InsertChainForDeposits([]types.IBlock{b1}, true)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(xshardList))
 }


### PR DESCRIPTION
This is the second PR split out from [QuarkChain/goquarkchain#689](https://github.com/QuarkChain/goquarkchain/pull/689), based on `fix/minor-chain-head-locking`.

### Issue / impact:

- Body/state in the DB does not mean x-shard broadcast and master header report are done.
- The old code mixed body present with committed, so after crash / retry it could not tell which blocks still needed commit side effects.
- During concurrent rewind, a marker could be written for a block whose body was already deleted.

### Root cause:

- `WriteBlockWithState` wrote the commit marker while writing body/state, marking the block committed too early.
- `HasBlock` meant both "does the body exist" and "is commit done".
- Marker write was not an atomic check-and-write with body existence.

### Fix:

- `WriteBlockWithState` / `insertSidechain` no longer auto-write the commit marker. The marker is written only by the shard layer after x-shard broadcast + master header report succeed.
- `HasBlock` now only means "body present"; add `HasCommittedBlock` for body + marker.
- `CommitMinorBlockByHash` checks under `m.mu` that the body still exists before writing the marker. If rewind already deleted the body, it returns `false`.
- sync / slave use `HasCommittedBlock` when deciding whether a block is complete, so body-only blocks are not treated as committed.
- Blocks with body/state but missing marker can be re-executed to recompute the x-shard list, then broadcast / reported / marked.
- Remove the obsolete `BLOCK_COMMITTING` placeholder state.

### Review focus:

- Should each call site use `HasBlock` or `HasCommittedBlock`?
- Is the marker written only after broadcast / report succeeds?
- Does `marker => body` hold on both commit and delete paths?

### Tests

Added/updated coverage for:

- commit marker is not written when the block body is missing
- `InsertChain` writes block body/state without automatically writing the commit marker
- shard API backend writes commit markers after `AddMinorBlock` / `AddBlockListForSync` propagation succeeds
- shard API backend skips already committed blocks and commits uncommitted blocks during sync import
- race-tagged shard API backend coverage for commit marker/body consistency
- sync test mocks now model committed minor blocks explicitly