### PR TITLE
fix: Recover Pruned Minor Sidechain Bodies Using Body-Only Anchors

### DIFF
--- a/cluster/shard/api_backend.go
+++ b/cluster/shard/api_backend.go
@@ -311,12 +311,14 @@ func (s *ShardBackend) NewMinorBlock(peerId string, block *types.MinorBlock) (er
 		return
 	}
 
-	if !s.MinorBlockChain.HasCommittedBlock(block.ParentHash()) {
+	// Body-only sidechain parents are allowed so a pruned-parent segment can
+	// keep accumulating bodies until state reconstruction becomes possible.
+	if !s.hasCommittedOrBodyWithoutState(block.ParentHash()) {
 		if err := s.commitUncommittedAncestorsIfPresent(block.ParentHash()); err != nil {
 			log.Warn(s.logInfo+" failed to commit uncommitted ancestors", "parent", block.ParentHash().Hex(), "err", err)
 			return nil
 		}
-		if !s.MinorBlockChain.HasCommittedBlock(block.ParentHash()) {
+		if !s.hasCommittedOrBodyWithoutState(block.ParentHash()) {
 			log.Debug("prarent block hash not be included", "parent hash: ", block.ParentHash().Hex())
 			return
 		}
@@ -342,6 +344,14 @@ func (s *ShardBackend) NewMinorBlock(peerId string, block *types.MinorBlock) (er
 	}
 
 	if err := s.MinorBlockChain.Validator().ValidateBlock(block, true); err != nil {
+		// A body-only parent means the segment is already in sidechain recovery.
+		// Insert this child body directly so replay can later reconstruct state.
+		if err == core.ErrPrunedAncestor && s.hasCommittedOrBodyWithoutState(block.ParentHash()) {
+			if err := s.AddMinorBlock(block); err != nil {
+				log.Warn(s.logInfo+" sidechain body recovery failed", "err", err)
+			}
+			return nil // next time to handle
+		}
 		log.Warn(s.logInfo+" ValidateBlock", "err", err)
 		return nil // next time to handle
 	}
@@ -376,23 +386,22 @@ func (s *ShardBackend) AddMinorBlock(block *types.MinorBlock) error {
 	}
 	currHead := s.MinorBlockChain.CurrentBlock().Header()
 	log.Debug(s.logInfo, "currHead", currHead.Number)
-	forceReplay := s.MinorBlockChain.HasBlockAndState(blockHash)
-	_, xshardLst, err := s.MinorBlockChain.InsertChainForDeposits([]types.IBlock{block}, forceReplay)
+	_, xshardBlocks, err := s.MinorBlockChain.InsertChainForDepositsWithBlocks([]types.IBlock{block}, true)
 	if err != nil {
-		log.Error(s.logInfo+" Failed to add minor block", "err", err, "len", len(xshardLst))
+		log.Error(s.logInfo+" Failed to add minor block", "err", err, "len", len(xshardBlocks))
 		return err
-	}
-
-	if len(xshardLst) != 1 {
-		log.Warn(s.logInfo+" already have this block", "number", block.NumberU64(), "hash", block.Hash().String())
-		return nil
 	}
 
 	// only remove from pool if the block successfully added to state,
 	// this may cache failed blocks but prevents them being broadcasted more than needed
 	s.mBPool.delBlockInPool(blockHash)
 
-	if xshardLst[0] == nil {
+	if handled, err := s.commitSidechainReplayIfNeeded(currHead, blockHash, xshardBlocks); handled {
+		return err
+	}
+
+	xshardLst := xshardBlocks[0].XShardList
+	if xshardLst == nil {
 		log.Info(s.logInfo+" add minor block has been added...", "branch", s.branch.Value, "height", block.Number())
 		if !s.MinorBlockChain.CommitMinorBlockByHash(blockHash) {
 			log.Warn(s.logInfo+" block body removed, cancelling commit", "hash", blockHash.Hex())
@@ -401,8 +410,13 @@ func (s *ShardBackend) AddMinorBlock(block *types.MinorBlock) error {
 		return nil
 	}
 
-	prevRootHeight := s.MinorBlockChain.GetRootBlockByHash(block.PrevRootBlockHash()).Number()
-	if err := s.conn.BroadcastXshardTxList(block, xshardLst[0], prevRootHeight); err != nil {
+	prevRootBlock := s.MinorBlockChain.GetRootBlockByHash(block.PrevRootBlockHash())
+	if prevRootBlock == nil {
+		s.setHead(currHead.Number)
+		return fmt.Errorf("prev root block not found: %s", block.PrevRootBlockHash().Hex())
+	}
+	prevRootHeight := prevRootBlock.Number()
+	if err := s.conn.BroadcastXshardTxList(block, xshardLst, prevRootHeight); err != nil {
 		s.setHead(currHead.Number)
 		return err
 	}
@@ -415,7 +429,7 @@ func (s *ShardBackend) AddMinorBlock(block *types.MinorBlock) error {
 	requests := &rpc.AddMinorBlockHeaderRequest{
 		MinorBlockHeader:  block.Header(),
 		TxCount:           uint32(block.Transactions().Len()),
-		XShardTxCount:     uint32(len(xshardLst[0])),
+		XShardTxCount:     uint32(len(xshardLst)),
 		ShardStats:        status,
 		CoinbaseAmountMap: block.CoinbaseAmount(),
 	}
@@ -428,18 +442,20 @@ func (s *ShardBackend) AddMinorBlock(block *types.MinorBlock) error {
 		log.Warn(s.logInfo+" block body removed, cancelling commit", "hash", blockHash.Hex())
 		return fmt.Errorf("%w: %s", ErrBodyDeleted, blockHash.Hex())
 	}
-	if s.MinorBlockChain.CurrentBlock().Hash() != currHead.Hash() {
-		go s.miner.HandleNewTip()
-	}
-	// block has been added to local state, broadcast tip so that peers can sync if needed
-	if currHead.Hash() != s.MinorBlockChain.CurrentBlock().Hash() {
-		if err = s.broadcastNewTip(); err != nil {
-			s.setHead(currHead.Number)
-			return err
-		}
-	}
 
+	if err := s.notifyMinorTipChanged(currHead); err != nil {
+		s.setHead(currHead.Number)
+		return err
+	}
 	return nil
+}
+
+func (s *ShardBackend) hasUncommittedBodyWithoutState(hash common.Hash) bool {
+	return !s.MinorBlockChain.HasCommittedBlock(hash) && s.MinorBlockChain.HasBodyWithoutState(hash)
+}
+
+func (s *ShardBackend) hasCommittedOrBodyWithoutState(hash common.Hash) bool {
+	return s.MinorBlockChain.HasCommittedBlock(hash) || s.hasUncommittedBodyWithoutState(hash)
 }
 
 func (s *ShardBackend) commitUncommittedAncestorsIfPresent(hash common.Hash) error {
@@ -466,6 +482,75 @@ func (s *ShardBackend) commitUncommittedAncestorsIfPresent(hash common.Hash) err
 	return nil
 }
 
+func (s *ShardBackend) commitSidechainReplayIfNeeded(currHead *types.MinorBlockHeader, requestedHash common.Hash, xShardBlocks []core.XShardListWithBlock) (bool, error) {
+	if len(xShardBlocks) == 0 {
+		return true, nil
+	}
+	if len(xShardBlocks) == 1 && xShardBlocks[0].Block.Hash() == requestedHash {
+		return false, nil
+	}
+
+	// Pruned sidechain replay can return x-shard lists for multiple historical
+	// blocks. Commit each list with its own block/header before returning.
+	if err := s.broadcastAndCommitXShardBlocks(xShardBlocks); err != nil {
+		s.setHead(currHead.Number)
+		return true, err
+	}
+	return true, s.notifyMinorTipChanged(currHead)
+}
+
+func (s *ShardBackend) notifyMinorTipChanged(currHead *types.MinorBlockHeader) error {
+	if s.MinorBlockChain.CurrentBlock().Hash() == currHead.Hash() {
+		return nil
+	}
+	go s.miner.HandleNewTip()
+	return s.broadcastNewTip()
+}
+
+func (s *ShardBackend) broadcastAndCommitXShardBlocks(xShardBlocks []core.XShardListWithBlock) error {
+	blockHashToXShardList := make(map[common.Hash]*XshardListTuple, len(xShardBlocks))
+	uncommittedBlockHeaderList := make([]*types.MinorBlockHeader, 0, len(xShardBlocks))
+
+	for _, xShardBlock := range xShardBlocks {
+		block := xShardBlock.Block
+		blockHash := block.Hash()
+		if s.getBlockCommitStatusByHash(blockHash) == BLOCK_COMMITTED {
+			continue
+		}
+		prevRootBlock := s.MinorBlockChain.GetRootBlockByHash(block.PrevRootBlockHash())
+		if prevRootBlock == nil {
+			return fmt.Errorf("prev root block not found: %s", block.PrevRootBlockHash().Hex())
+		}
+		blockHashToXShardList[blockHash] = &XshardListTuple{
+			XshardTxList:   xShardBlock.XShardList,
+			PrevRootHeight: prevRootBlock.Number(),
+		}
+		uncommittedBlockHeaderList = append(uncommittedBlockHeaderList, block.Header())
+	}
+	if len(uncommittedBlockHeaderList) == 0 {
+		return nil
+	}
+
+	if err := s.conn.BatchBroadcastXshardTxList(blockHashToXShardList, s.branch); err != nil {
+		return err
+	}
+	req := &rpc.AddMinorBlockHeaderListRequest{
+		MinorBlockHeaderList: uncommittedBlockHeaderList,
+	}
+	if err := s.conn.SendMinorBlockHeaderListToMaster(req); err != nil {
+		return err
+	}
+	for _, header := range uncommittedBlockHeaderList {
+		blockHash := header.Hash()
+		if !s.MinorBlockChain.CommitMinorBlockByHash(blockHash) {
+			log.Warn(s.logInfo+" block body removed, cancelling commit", "hash", blockHash.Hex())
+			return fmt.Errorf("%w: %s", ErrBodyDeleted, blockHash.Hex())
+		}
+		s.mBPool.delBlockInPool(blockHash)
+	}
+	return nil
+}
+
 // Add blocks in batch to reduce RPCs. Will NOT broadcast to peers.
 //
 // Returns true if blocks are successfully added. False on any error.
@@ -482,53 +567,50 @@ func (s *ShardBackend) AddBlockListForSync(blockLst []*types.MinorBlock) error {
 		return nil
 	}
 
-	var (
-		blockHashToXShardList      = make(map[common.Hash]*XshardListTuple)
-		uncommittedBlockHeaderList = make([]*types.MinorBlockHeader, 0, len(blockLst))
-	)
+	seenInBatch := make(map[common.Hash]struct{})
+	chain := make([]types.IBlock, 0, len(blockLst))
 	for _, block := range blockLst {
 		blockHash := block.Hash()
 		if block.Branch().Value != s.branch.Value {
 			continue
 		}
 		if s.getBlockCommitStatusByHash(blockHash) == BLOCK_COMMITTED {
+			log.Debug(s.logInfo+" minor block to sync is already committed", "hash", blockHash.Hex())
 			continue
 		}
-		forceReplay := s.MinorBlockChain.HasBlockAndState(blockHash)
-		_, xshardLst, err := s.MinorBlockChain.InsertChainForDeposits([]types.IBlock{block}, forceReplay)
-		if err != nil {
-			log.Error(s.logInfo+" Failed to add minor block", "err", err)
-			return err
+		if _, ok := seenInBatch[blockHash]; ok {
+			log.Debug(s.logInfo+" duplicate block in sync batch, skipping", "hash", blockHash.Hex())
+			continue
 		}
-		if len(xshardLst) != 1 {
-			log.Warn(s.logInfo+" already have this block", "number", block.NumberU64(), "hash", block.Hash().String())
-			return nil
-		}
-		s.mBPool.delBlockInPool(block.Hash())
-		prevRootHeight := s.MinorBlockChain.GetRootBlockByHash(block.PrevRootBlockHash())
-		blockHashToXShardList[blockHash] = &XshardListTuple{XshardTxList: xshardLst[0], PrevRootHeight: prevRootHeight.Number()}
-		uncommittedBlockHeaderList = append(uncommittedBlockHeaderList, block.Header())
-	}
-	// interrupt the current miner and restart
-	if err := s.conn.BatchBroadcastXshardTxList(blockHashToXShardList, blockLst[0].Branch()); err != nil {
-		return err
-	}
+		seenInBatch[blockHash] = struct{}{}
 
-	req := &rpc.AddMinorBlockHeaderListRequest{
-		MinorBlockHeaderList: uncommittedBlockHeaderList,
+		if len(chain) > 0 {
+			prev := chain[len(chain)-1]
+			if block.NumberU64() != prev.NumberU64()+1 || block.ParentHash() != prev.Hash() {
+				if err := s.insertAndCommitSyncSegment(chain); err != nil {
+					return err
+				}
+				chain = chain[:0]
+			}
+		}
+		chain = append(chain, block)
 	}
-	if err := s.conn.SendMinorBlockHeaderListToMaster(req); err != nil {
+	return s.insertAndCommitSyncSegment(chain)
+}
+
+func (s *ShardBackend) insertAndCommitSyncSegment(chain []types.IBlock) error {
+	if len(chain) == 0 {
+		return nil
+	}
+	_, xShardBlocks, err := s.MinorBlockChain.InsertChainForDepositsWithBlocks(chain, true)
+	if err != nil {
+		log.Error(s.logInfo+" Failed to add minor block segment", "err", err)
 		return err
 	}
-	for _, header := range uncommittedBlockHeaderList {
-		blockHash := header.Hash()
-		if !s.MinorBlockChain.CommitMinorBlockByHash(blockHash) {
-			log.Warn(s.logInfo+" block body removed, cancelling commit", "hash", blockHash.Hex())
-			return fmt.Errorf("%w: %s", ErrBodyDeleted, blockHash.Hex())
-		}
-		s.mBPool.delBlockInPool(blockHash)
+	for _, block := range chain {
+		s.mBPool.delBlockInPool(block.Hash())
 	}
-	return nil
+	return s.broadcastAndCommitXShardBlocks(xShardBlocks)
 }
 
 // ######################## miner Methods ##############################

--- a/cluster/shard/api_backend.go
+++ b/cluster/shard/api_backend.go
@@ -471,6 +471,9 @@ func (s *ShardBackend) commitUncommittedAncestorsIfPresent(hash common.Hash) err
 	if len(blocks) == 0 || !s.MinorBlockChain.HasCommittedBlock(hash) {
 		return nil
 	}
+	// Replay missing commit markers from oldest ancestor to newest. Each
+	// AddMinorBlock re-checks the block status, so concurrent tip changes can
+	// safely leave any unfinished ancestors for the next retry.
 	for i := len(blocks) - 1; i >= 0; i-- {
 		if err := s.AddMinorBlock(blocks[i]); err != nil {
 			return err
@@ -531,6 +534,9 @@ func (s *ShardBackend) broadcastAndCommitXShardBlocks(xShardBlocks []core.XShard
 		return nil
 	}
 
+	// The commit marker means x-shard txs and minor headers were already sent, so
+	// send them before writing the marker. If the marker write fails, the block
+	// stays uncommitted and sync will resend it later.
 	if err := s.conn.BatchBroadcastXshardTxList(blockHashToXShardList, s.branch); err != nil {
 		return err
 	}

--- a/cluster/shard/api_backend_test.go
+++ b/cluster/shard/api_backend_test.go
@@ -3,6 +3,7 @@ package shard
 import (
 	"errors"
 	"math/big"
+	"sync"
 	"testing"
 
 	"github.com/QuarkChain/goquarkchain/account"
@@ -19,25 +20,57 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-type stubConnManager struct{}
+type stubConnManager struct {
+	mu sync.Mutex
+
+	broadcastXshardCount      int
+	sendMinorHeaderCount      int
+	sendMinorHeaderListCount  int
+	batchBroadcastXshardCount int
+	broadcastNewTipCount      int
+	broadcastMinorBlockCount  int
+
+	lastBatchXshardLists map[common.Hash]*XshardListTuple
+	lastHeaderList       []*types.MinorBlockHeader
+}
 
 func (s *stubConnManager) BroadcastXshardTxList(_ *types.MinorBlock, _ []*types.CrossShardTransactionDeposit, _ uint32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.broadcastXshardCount++
 	return nil
 }
 
 func (s *stubConnManager) SendMinorBlockHeaderToMaster(_ *rpc.AddMinorBlockHeaderRequest) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sendMinorHeaderCount++
 	return nil
 }
 
-func (s *stubConnManager) SendMinorBlockHeaderListToMaster(_ *rpc.AddMinorBlockHeaderListRequest) error {
+func (s *stubConnManager) SendMinorBlockHeaderListToMaster(req *rpc.AddMinorBlockHeaderListRequest) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sendMinorHeaderListCount++
+	s.lastHeaderList = append([]*types.MinorBlockHeader(nil), req.MinorBlockHeaderList...)
 	return nil
 }
 
-func (s *stubConnManager) BatchBroadcastXshardTxList(_ map[common.Hash]*XshardListTuple, _ account.Branch) error {
+func (s *stubConnManager) BatchBroadcastXshardTxList(lists map[common.Hash]*XshardListTuple, _ account.Branch) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.batchBroadcastXshardCount++
+	s.lastBatchXshardLists = make(map[common.Hash]*XshardListTuple, len(lists))
+	for hash, list := range lists {
+		s.lastBatchXshardLists[hash] = list
+	}
 	return nil
 }
 
 func (s *stubConnManager) BroadcastNewTip(_ []*types.MinorBlockHeader, _ *types.RootBlockHeader, _ uint32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.broadcastNewTipCount++
 	return nil
 }
 
@@ -46,6 +79,9 @@ func (s *stubConnManager) BroadcastTransactions(_ string, _ uint32, _ []*types.T
 }
 
 func (s *stubConnManager) BroadcastMinorBlock(_ string, _ *types.MinorBlock) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.broadcastMinorBlockCount++
 	return nil
 }
 
@@ -130,6 +166,25 @@ func makeTestMinorBlocks(t *testing.T, db ethdb.Database, parent *types.MinorBlo
 	return blocks
 }
 
+func makeDetachedTestMinorBlocks(t *testing.T, parent *types.MinorBlock, n int) []*types.MinorBlock {
+	t.Helper()
+
+	clusterCfg := config.NewClusterConfig()
+	clusterCfg.Quarkchain.SkipMinorDifficultyCheck = true
+	clusterCfg.Quarkchain.SkipRootDifficultyCheck = true
+	clusterCfg.Quarkchain.SkipRootCoinbaseCheck = true
+	fullShardID := clusterCfg.Quarkchain.Chains[0].ShardSize | 0
+
+	db := ethdb.NewMemDatabase()
+	gspec := core.NewGenesis(clusterCfg.Quarkchain)
+	rootBlock := gspec.CreateRootBlock()
+	genesisBlock := gspec.MustCommitMinorBlock(db, rootBlock, fullShardID)
+	if genesisBlock.Hash() != parent.Hash() {
+		t.Fatalf("detached genesis hash mismatch: got %s want %s", genesisBlock.Hash().Hex(), parent.Hash().Hex())
+	}
+	return makeTestMinorBlocks(t, db, genesisBlock, n)
+}
+
 func makeTestForkBlock(t *testing.T, db ethdb.Database, parent *types.MinorBlock) *types.MinorBlock {
 	t.Helper()
 	blocks, _ := core.GenerateMinorBlockChain(
@@ -144,6 +199,10 @@ func makeTestForkBlock(t *testing.T, db ethdb.Database, parent *types.MinorBlock
 		},
 	)
 	return blocks[0]
+}
+
+func shardStubConn(sb *ShardBackend) *stubConnManager {
+	return sb.conn.(*stubConnManager)
 }
 
 func TestAddBlockListForSyncSkipsCommittedBlockAndCommitsRest(t *testing.T) {
@@ -170,6 +229,36 @@ func TestAddBlockListForSyncSkipsCommittedBlockAndCommitsRest(t *testing.T) {
 	}
 	if sb.MinorBlockChain.CurrentBlock().Hash() != blockB.Hash() {
 		t.Fatalf("chain tip should be blockB, got %s", sb.MinorBlockChain.CurrentBlock().Hash().Hex())
+	}
+}
+
+func TestAddBlockListForSyncSplitsGapAndSkipsDuplicateInBatch(t *testing.T) {
+	sb, db, stop := newTestShardBackend(t)
+	defer stop()
+
+	genesis := sb.MinorBlockChain.CurrentBlock()
+	blockA := makeTestMinorBlocks(t, db, genesis, 1)[0]
+	blockAFork := makeTestForkBlock(t, db, genesis)
+
+	if err := sb.AddBlockListForSync([]*types.MinorBlock{blockA, blockA, blockAFork}); err != nil {
+		t.Fatalf("AddBlockListForSync: %v", err)
+	}
+	if !sb.MinorBlockChain.HasCommittedBlock(blockA.Hash()) {
+		t.Fatal("first segment block should be committed")
+	}
+	if !sb.MinorBlockChain.HasCommittedBlock(blockAFork.Hash()) {
+		t.Fatal("fork segment block should be committed")
+	}
+
+	conn := shardStubConn(sb)
+	if conn.batchBroadcastXshardCount != 2 {
+		t.Fatalf("expected duplicate-skipped fork batch to split into two x-shard broadcasts, got %d", conn.batchBroadcastXshardCount)
+	}
+	if conn.sendMinorHeaderListCount != 2 {
+		t.Fatalf("expected duplicate-skipped fork batch to split into two header submissions, got %d", conn.sendMinorHeaderListCount)
+	}
+	if conn.sendMinorHeaderCount != 0 {
+		t.Fatalf("sync batch should use header-list submission, got %d single-header submissions", conn.sendMinorHeaderCount)
 	}
 }
 
@@ -235,5 +324,73 @@ func TestNewMinorBlockRecoversUncommittedBody(t *testing.T) {
 	}
 	if !sb.MinorBlockChain.HasCommittedBlock(block.Hash()) {
 		t.Fatal("NewMinorBlock should route existing uncommitted body through AddMinorBlock")
+	}
+}
+
+func TestNewMinorBlockAcceptsBodyOnlyParentAsSidechainAnchor(t *testing.T) {
+	sb, db, stop := newTestShardBackend(t)
+	defer stop()
+
+	blocks := makeDetachedTestMinorBlocks(t, sb.MinorBlockChain.CurrentBlock(), 2)
+	parent, child := blocks[0], blocks[1]
+	if err := sb.MinorBlockChain.WriteBlockWithoutState(parent); err != nil {
+		t.Fatalf("write body-only parent: %v", err)
+	}
+	if !sb.MinorBlockChain.HasBodyWithoutState(parent.Hash()) {
+		t.Fatal("parent should be body-only before receiving child")
+	}
+
+	if err := sb.NewMinorBlock("peer-1", child); err != nil {
+		t.Fatalf("NewMinorBlock with body-only parent: %v", err)
+	}
+	if !rawdb.HasBlock(db, child.Hash()) {
+		t.Fatal("child body should be written as sidechain data")
+	}
+	if !sb.MinorBlockChain.HasCommittedBlock(child.Hash()) {
+		t.Fatal("child should be committed after body-only sidechain replay")
+	}
+	if !sb.MinorBlockChain.HasCommittedBlock(parent.Hash()) {
+		t.Fatal("parent should also be committed after sidechain replay")
+	}
+}
+
+func TestCommitSidechainReplayCommitsEveryReturnedBlock(t *testing.T) {
+	sb, db, stop := newTestShardBackend(t)
+	defer stop()
+
+	blocks := makeTestMinorBlocks(t, db, sb.MinorBlockChain.CurrentBlock(), 2)
+	for _, block := range blocks {
+		rawdb.WriteMinorBlock(db, block)
+	}
+	xshardBlocks := []core.XShardListWithBlock{
+		{Block: blocks[0], XShardList: []*types.CrossShardTransactionDeposit{}},
+		{Block: blocks[1], XShardList: []*types.CrossShardTransactionDeposit{}},
+	}
+
+	handled, err := sb.commitSidechainReplayIfNeeded(sb.MinorBlockChain.CurrentBlock().Header(), blocks[1].Hash(), xshardBlocks)
+	if err != nil {
+		t.Fatalf("commitSidechainReplayIfNeeded: %v", err)
+	}
+	if !handled {
+		t.Fatal("multi-block sidechain replay should be handled")
+	}
+	for _, block := range blocks {
+		if !sb.MinorBlockChain.HasCommittedBlock(block.Hash()) {
+			t.Fatalf("block %s should be committed after sidechain replay", block.Hash().Hex())
+		}
+	}
+
+	conn := shardStubConn(sb)
+	if conn.batchBroadcastXshardCount != 1 {
+		t.Fatalf("expected one batch x-shard broadcast, got %d", conn.batchBroadcastXshardCount)
+	}
+	if conn.sendMinorHeaderListCount != 1 {
+		t.Fatalf("expected one header-list submission, got %d", conn.sendMinorHeaderListCount)
+	}
+	if len(conn.lastBatchXshardLists) != len(blocks) {
+		t.Fatalf("expected %d x-shard entries, got %d", len(blocks), len(conn.lastBatchXshardLists))
+	}
+	if len(conn.lastHeaderList) != len(blocks) {
+		t.Fatalf("expected %d submitted headers, got %d", len(blocks), len(conn.lastHeaderList))
 	}
 }

--- a/cluster/sync/minor_task.go
+++ b/cluster/sync/minor_task.go
@@ -207,7 +207,7 @@ func (m *minorChainTask) findAncestor(bc blockchain) (*types.MinorBlockHeader, e
 			}
 			preHeader = mh
 
-			if !bc.HasCommittedBlock(mh.Hash()) {
+			if !bc.HasCommittedBlock(mh.Hash()) && !bc.HasBodyWithoutState(mh.Hash()) {
 				end = mh.Number - 1
 				continue
 			}

--- a/cluster/sync/minor_task_test.go
+++ b/cluster/sync/minor_task_test.go
@@ -212,9 +212,74 @@ func TestMinorChainTask(t *testing.T) {
 	assert.Equal(t, bc.CurrentHeader().NumberU64(), uint64(2000+20))
 }
 
+func TestMinorFindAncestorUsesCommittedOrBodyWithoutState(t *testing.T) {
+	bc, db := newMinorBlockChain(0)
+	mbc := bc.(*mockblockchain).mbc
+	defer mbc.Stop()
+
+	_, headers := makeMinorChains(mbc.GetBlockByNumber(0).(*types.MinorBlock), 5, db, false)
+	p := &mockpeer{retMHeaders: headers}
+	mTask := NewMinorChainTask(p, headers[5]).(*minorChainTask)
+	states := &ancestorStateBlockchain{
+		current:          headers[4],
+		bodies:           make(map[common.Hash]bool),
+		committed:        make(map[common.Hash]bool),
+		bodyWithoutState: make(map[common.Hash]bool),
+	}
+	for _, header := range headers[:5] {
+		states.bodies[header.Hash()] = true
+	}
+
+	// #4 has body+state but no marker, so it must be retried rather than used
+	// as the anchor. #3 is body-only, so it can keep sidechain download moving.
+	states.committed[headers[2].Hash()] = true
+	states.bodyWithoutState[headers[3].Hash()] = true
+
+	ancestor, err := mTask.findAncestor(states)
+	assert.NoError(t, err)
+	assert.Equal(t, headers[3].Hash(), ancestor.Hash())
+
+	// Once #4 is committed, it becomes the best local anchor.
+	states.committed[headers[4].Hash()] = true
+	ancestor, err = mTask.findAncestor(states)
+	assert.NoError(t, err)
+	assert.Equal(t, headers[4].Hash(), ancestor.Hash())
+}
+
 /*
  Test helpers.
 */
+
+type ancestorStateBlockchain struct {
+	current          *types.MinorBlockHeader
+	bodies           map[common.Hash]bool
+	committed        map[common.Hash]bool
+	bodyWithoutState map[common.Hash]bool
+}
+
+func (bc *ancestorStateBlockchain) HasCommittedBlock(hash common.Hash) bool {
+	return bc.committed[hash]
+}
+
+func (bc *ancestorStateBlockchain) HasBlock(hash common.Hash) bool {
+	return bc.bodies[hash]
+}
+
+func (bc *ancestorStateBlockchain) HasBodyWithoutState(hash common.Hash) bool {
+	return bc.bodyWithoutState[hash]
+}
+
+func (bc *ancestorStateBlockchain) AddBlock(types.IBlock) error {
+	return nil
+}
+
+func (bc *ancestorStateBlockchain) CurrentHeader() types.IHeader {
+	return bc.current
+}
+
+func (bc *ancestorStateBlockchain) Validator() core.Validator {
+	return nil
+}
 
 func makeMinorChains(parent *types.MinorBlock, height int, db ethdb.Database, random bool) ([]*types.MinorBlock, []*types.MinorBlockHeader) {
 	var gen func(config *config.QuarkChainConfig, i int, b *core.MinorBlockGen)

--- a/cluster/sync/root_task_test.go
+++ b/cluster/sync/root_task_test.go
@@ -148,6 +148,13 @@ func (bc *mockblockchain) HasCommittedBlock(hash common.Hash) bool {
 	return bc.mbc.HasCommittedBlock(hash)
 }
 
+func (bc *mockblockchain) HasBodyWithoutState(hash common.Hash) bool {
+	if bc.rbc != nil {
+		return false
+	}
+	return bc.mbc.HasBodyWithoutState(hash)
+}
+
 func (bc *mockblockchain) AddBlock(block types.IBlock) error {
 	if bc.rbc != nil {
 		_, err := bc.rbc.InsertChain([]types.IBlock{block})

--- a/cluster/sync/sync.go
+++ b/cluster/sync/sync.go
@@ -15,6 +15,7 @@ import (
 type blockchain interface {
 	HasBlock(common.Hash) bool
 	HasCommittedBlock(common.Hash) bool
+	HasBodyWithoutState(common.Hash) bool
 	AddBlock(types.IBlock) error
 	CurrentHeader() types.IHeader
 	Validator() core.Validator

--- a/core/minorblockchain.go
+++ b/core/minorblockchain.go
@@ -565,6 +565,14 @@ func (m *MinorBlockChain) HasBlock(hash common.Hash) bool {
 	return rawdb.HasBlock(m.db, hash)
 }
 
+// HasBodyWithoutState reports whether the block body exists while its state
+// trie is missing. Such a block can anchor sidechain body download, but it is
+// not a committed block.
+func (m *MinorBlockChain) HasBodyWithoutState(hash common.Hash) bool {
+	block := m.GetMinorBlock(hash)
+	return block != nil && !m.HasState(block.Root())
+}
+
 // HasState checks if state trie is fully present in the database or not.
 func (m *MinorBlockChain) HasState(hash common.Hash) bool {
 	_, err := m.stateCache.OpenTrie(hash)
@@ -1043,6 +1051,24 @@ func (m *MinorBlockChain) InsertChain(chain []types.IBlock, isCheckDB bool) (int
 // InsertChainForDeposits also return cross-shard transaction deposits in addition
 // to content returned from `InsertChain`.
 func (m *MinorBlockChain) InsertChainForDeposits(chain []types.IBlock, isCheckDB bool) (int, [][]*types.CrossShardTransactionDeposit, error) {
+	n, xShardBlocks, err := m.insertChainForDepositsWithBlocks(chain, isCheckDB, isCheckDB)
+	xShardList := make([][]*types.CrossShardTransactionDeposit, 0, len(xShardBlocks))
+	for _, xShardBlock := range xShardBlocks {
+		xShardList = append(xShardList, xShardBlock.XShardList)
+	}
+	return n, xShardList, err
+}
+
+type XShardListWithBlock struct {
+	Block      *types.MinorBlock
+	XShardList []*types.CrossShardTransactionDeposit
+}
+
+func (m *MinorBlockChain) InsertChainForDepositsWithBlocks(chain []types.IBlock, force bool) (int, []XShardListWithBlock, error) {
+	return m.insertChainForDepositsWithBlocks(chain, force, false)
+}
+
+func (m *MinorBlockChain) insertChainForDepositsWithBlocks(chain []types.IBlock, force bool, isCheckDB bool) (int, []XShardListWithBlock, error) {
 	// Sanity check that we have something meaningful to import
 	if len(chain) == 0 {
 		return 0, nil, nil
@@ -1061,7 +1087,7 @@ func (m *MinorBlockChain) InsertChainForDeposits(chain []types.IBlock, isCheckDB
 	// Pre-checks passed, start the full block imports
 	m.wg.Add(1)
 	m.chainmu.Lock()
-	n, events, logs, xShardList, err := m.insertChain(chain, true, isCheckDB)
+	n, events, logs, xShardList, err := m.insertChain(chain, true, force, isCheckDB)
 	m.chainmu.Unlock()
 	m.wg.Done()
 
@@ -1086,8 +1112,8 @@ func (m *MinorBlockChain) InsertChainForDeposits(chain []types.IBlock, isCheckDB
 // racey behaviour. If a sidechain import is in progress, and the historic state
 // is imported, but then new canon-head is added before the actual sidechain
 // completes, then the historic state could be pruned again
-func (m *MinorBlockChain) insertChain(chain []types.IBlock, verifySeals bool, isCheckDB bool) (int, []interface{}, []*types.Log, [][]*types.CrossShardTransactionDeposit, error) {
-	xShardList := make([][]*types.CrossShardTransactionDeposit, 0)
+func (m *MinorBlockChain) insertChain(chain []types.IBlock, verifySeals bool, force bool, isCheckDB bool) (int, []interface{}, []*types.Log, []XShardListWithBlock, error) {
+	xShardList := make([]XShardListWithBlock, 0)
 	// If the chain is terminating, don't even bother starting u
 	if atomic.LoadInt32(&m.procInterrupt) == 1 {
 		return 0, nil, nil, xShardList, nil
@@ -1110,12 +1136,12 @@ func (m *MinorBlockChain) insertChain(chain []types.IBlock, verifySeals bool, is
 	)
 
 	// Peek the error for the first block to decide the directing import logic
-	it := newInsertIterator(chain, m.Validator(), isCheckDB)
+	it := newInsertIterator(chain, m.Validator(), force)
 	block, err := it.next()
 	switch {
 	// First block is pruned, insert as sidechain and reorg only if TD grows enough
 	case err == ErrPrunedAncestor:
-		return m.insertSidechain(it, isCheckDB)
+		return m.insertSidechain(it, force, isCheckDB)
 
 	// First block is future, shove it (and all children) to the future queue (unknown ancestor)
 	case err == ErrFutureBlock || (err == ErrUnknownAncestor && m.futureBlocks.Contains(it.first().ParentHash())):
@@ -1181,15 +1207,18 @@ func (m *MinorBlockChain) insertChain(chain []types.IBlock, verifySeals bool, is
 			return it.index, events, coalescedLogs, xShardList, err
 		}
 
-		if isCheckDB && m.HasBlockAndState(mBlock.Hash()) {
-			xShardList = append(xShardList, state.GetXShardList())
+		if force && m.HasBlockAndState(mBlock.Hash()) {
+			// Body and state already exist. Re-execute only to recover the
+			// outgoing x-shard list, then keep processing later blocks.
+			xShardList = append(xShardList, XShardListWithBlock{Block: mBlock, XShardList: state.GetXShardList()})
 			continue
 		}
 
 		if isCheckDB {
-			xShardList = append(xShardList, state.GetXShardList())
+			xShardList = append(xShardList, XShardListWithBlock{Block: mBlock, XShardList: state.GetXShardList()})
 			return 0, events, coalescedLogs, xShardList, nil
 		}
+
 		updateTip, err := m.updateTip(state, mBlock)
 		if err != nil {
 			return it.index, events, coalescedLogs, xShardList, err
@@ -1221,7 +1250,7 @@ func (m *MinorBlockChain) insertChain(chain []types.IBlock, verifySeals bool, is
 		stats.usedGas += usedGas
 
 		//	stats.report(chain, it.index)
-		xShardList = append(xShardList, state.GetXShardList())
+		xShardList = append(xShardList, XShardListWithBlock{Block: mBlock, XShardList: state.GetXShardList()})
 	}
 	// Any blocks remaining here? The only ones we care about are the future ones
 	if !qkcCommon.IsNil(block) && err == ErrFutureBlock {
@@ -1252,7 +1281,7 @@ func (m *MinorBlockChain) insertChain(chain []types.IBlock, verifySeals bool, is
 //
 // The method writes all (header-and-body-valid) blocks to disk, then tries to
 // switch over to the new chain if the TD exceeded the current chain.
-func (m *MinorBlockChain) insertSidechain(it *insertIterator, isCheckDB bool) (int, []interface{}, []*types.Log, [][]*types.CrossShardTransactionDeposit, error) {
+func (m *MinorBlockChain) insertSidechain(it *insertIterator, force bool, isCheckDB bool) (int, []interface{}, []*types.Log, []XShardListWithBlock, error) {
 	var (
 		current      = m.CurrentBlock().NumberU64()
 		externHeight = uint64(0)
@@ -1314,13 +1343,14 @@ func (m *MinorBlockChain) insertSidechain(it *insertIterator, isCheckDB bool) (i
 
 		parent = m.GetBlock(parent.ParentHash())
 	}
-	if parent == nil {
+	if qkcCommon.IsNil(parent) {
 		return it.index, nil, nil, nil, errors.New("missing parent")
 	}
 	// Import all the pruned blocks to make the state available
 	var (
-		blocks []types.IBlock
-		memory common.StorageSize
+		blocks     []types.IBlock
+		memory     common.StorageSize
+		xShardList []XShardListWithBlock
 	)
 	for i := len(hashes) - 1; i >= 0; i-- {
 		// Append the next block to our batch
@@ -1333,23 +1363,27 @@ func (m *MinorBlockChain) insertSidechain(it *insertIterator, isCheckDB bool) (i
 		// memory here.
 		if len(blocks) >= 2048 || memory > 64*1024*1024 {
 			log.Info("Importing heavy sidechain segment", "blocks", len(blocks), "start", blocks[0].NumberU64(), "end", block.NumberU64())
-			if _, _, _, _, err := m.insertChain(blocks, false, isCheckDB); err != nil {
+			_, _, _, segmentXShardList, err := m.insertChain(blocks, false, force, isCheckDB)
+			if err != nil {
 				return 0, nil, nil, nil, err
 			}
+			xShardList = append(xShardList, segmentXShardList...)
 			blocks, memory = blocks[:0], 0
 
 			// If the chain is terminating, stop processing blocks
 			if atomic.LoadInt32(&m.procInterrupt) == 1 {
 				log.Debug("Premature abort during blocks processing")
-				return 0, nil, nil, nil, nil
+				return 0, nil, nil, xShardList, nil
 			}
 		}
 	}
 	if len(blocks) > 0 {
 		log.Info("Importing sidechain segment", "start", blocks[0].NumberU64(), "end", blocks[len(blocks)-1].NumberU64())
-		return m.insertChain(blocks, false, isCheckDB)
+		n, events, logs, segmentXShardList, err := m.insertChain(blocks, false, force, isCheckDB)
+		xShardList = append(xShardList, segmentXShardList...)
+		return n, events, logs, xShardList, err
 	}
-	return 0, nil, nil, nil, nil
+	return 0, nil, nil, xShardList, nil
 }
 
 // reorgs takes two blocks, an old chain and a new chain and will reconstruct the blocks and inserts them

--- a/core/rootblockchain.go
+++ b/core/rootblockchain.go
@@ -350,6 +350,12 @@ func (bc *RootBlockChain) HasCommittedBlock(hash common.Hash) bool {
 	return bc.HasBlock(hash)
 }
 
+// HasBodyWithoutState satisfies the sync.blockchain interface. Root sync does
+// not have minor-chain body-only state reconstruction semantics.
+func (bc *RootBlockChain) HasBodyWithoutState(hash common.Hash) bool {
+	return false
+}
+
 // GetBlock retrieves a block from the database by hash and number,
 // caching it if found.
 func (bc *RootBlockChain) GetBlock(hash common.Hash) types.IBlock {


### PR DESCRIPTION
**Description**

This is the third PR split out from [[QuarkChain/goquarkchain#689](https://github.com/QuarkChain/goquarkchain/pull/689)](https://github.com/QuarkChain/goquarkchain/pull/689), based on `fix/minor-block-commit-status`.

### Background

First, what insert sidechain / sidechain replay means (following the go-ethereum mechanism)

- When importing a batch, if the fork point is too old and the parent's **state trie has been pruned**
  (`ErrPrunedAncestor`), the chain enters sidechain import: those blocks **only write body, not state,
  not canonical index, and not commit marker**. The fork may never be adopted, so keeping only the body is cheap.
- Only when this fork's **cumulative height / difficulty exceeds the current main chain** and the node really
  switches to it does replay start from the nearest ancestor that still has state. The body-only blocks are
  replayed one by one to rebuild state, and reorg moves the canonical chain to that fork. This is the step
  that produces x-shard lists, so this is also when broadcast / report / marker writes are needed.
- For this change set: **normal body/state blocks still need `HasCommittedBlock` to count as ancestors;
  only pruned sidechain blocks can use `HasBodyWithoutState` as local data to avoid re-download**.
  That still does not mean committed. During replay + reorg, one pass can replay multiple historical blocks,
  and each of them must complete broadcast / report / marker write in order.

### Issue / impact:

- **Existing pruned sidechain bodies may be downloaded again**: after PR2, body-only no longer means committed.
  Normal body/state blocks still use `HasCommittedBlock`; but for `HasBodyWithoutState` pruned sidechain blocks,
  the body is already in the DB. If sync does not treat those blocks as local, `findAncestor` can walk past
  them and re-download historical bodies from peers.
- **Sidechain replay may miss the commit step for historical blocks**: when a pruned sidechain becomes
  canonical, replay can execute multiple historical blocks and produce an x-shard list for each block.
  The old shard commit path was mostly written for "the single block or blocks currently requested", not for
  "commit multiple replayed historical blocks in order".
- **A parent with body/state but missing marker can block live propagation**: if the node crashes after
  body/state write but before marker write, then after restart a child block sees the parent as not committed.
  The node needs to finish broadcast / report / marker for the parent and earlier ancestors before processing the child.

### Root cause:

- The old sync logic only had a committed / not-committed check, so it did not separately handle pruned sidechain bodies already in the DB.
- The old shard commit path was single-block oriented and did not cover sidechain replay recovering multiple historical blocks at once.
- `NewMinorBlock` assumed the current block could be handled directly, without first checking whether its parent chain had local blocks missing markers.

### Fix:

- sync `findAncestor` uses `HasCommittedBlock || HasBodyWithoutState` for ancestor lookup:
  normal blocks must be committed, while pruned sidechain blocks only need their body in the DB. This avoids
  re-downloading historical bodies already in the DB; if no common ancestor is found, it returns a normal error instead of nil-panic.
- sidechain replay can return x-shard lists for **multiple historical blocks**, and they are broadcast / reported / committed in chain order.
- `AddBlockListForSync` imports by contiguous segment. If the batch is not contiguous, it commits the previous
  segment first; the next segment still goes through normal parent/state validation, so a missing parent fails
  and waits for a later sync retry.
- `NewMinorBlock` first tries to finish uncommitted ancestors when the parent has body/state but misses marker; if the parent is a body-only sidechain block, it writes the child body to the DB and lets later replay rebuild state.
- Commit marker meaning stays the same: write marker only after broadcast / report is sent; if marker write fails, the block stays uncommitted and sync retry sends it again.

### Review focus:

- Is `HasBodyWithoutState` used only as local sync data, never mistaken for committed?
- Does multi-block sidechain replay commit in chain order?
- After replay / commit failure, does the block stay uncommitted so sync retry can recover it?

### Tests

Added coverage for:

- minor sync choosing body-only blocks as ancestors while still retrying body+state-but-uncommitted blocks
- `NewMinorBlock` accepting a body-only parent as a sidechain anchor
- multi-block sidechain replay committing every returned block
- sync batch split on gaps/forks and duplicate skipping within one batch
- root sync mocks preserving the new interface without changing root semantics