### PR TITLE
fix (part 2): remove minor block commit marker

### DIFF
--- a/cluster/master/master_grpc.go
+++ b/cluster/master/master_grpc.go
@@ -3,9 +3,8 @@ package master
 import (
 	"context"
 	"sync"
-
+	
 	"github.com/QuarkChain/goquarkchain/cluster/rpc"
-	"github.com/QuarkChain/goquarkchain/core/types"
 	"github.com/QuarkChain/goquarkchain/serialize"
 )
 
@@ -22,27 +21,14 @@ func NewServerSideOp(master *QKCMasterBackend) *MasterServerSideOp {
 	}
 }
 
-// addValidatedMinorBlockHeader records a header once. The caller must hold m.mu.
-func (m *MasterServerSideOp) addValidatedMinorBlockHeader(header *types.MinorBlockHeader, coinbaseAmount *types.TokenBalances) bool {
-	hash := header.Hash()
-	if m.master.rootBlockChain.IsMinorBlockValidated(hash) {
-		return false
-	}
-	m.master.rootBlockChain.AddValidatedMinorBlockHeader(hash, coinbaseAmount)
-	return true
-}
-
 func (m *MasterServerSideOp) AddMinorBlockHeader(ctx context.Context, req *rpc.Request) (*rpc.Response, error) {
 	data := new(rpc.AddMinorBlockHeaderRequest)
 	if err := serialize.DeserializeFromBytes(req.Data, data); err != nil {
 		return nil, err
 	}
-	m.mu.Lock()
-	if m.addValidatedMinorBlockHeader(data.MinorBlockHeader, data.CoinbaseAmountMap) {
-		m.master.UpdateTxCountHistory(data.TxCount, data.XShardTxCount, data.MinorBlockHeader.Time)
-	}
+	m.master.rootBlockChain.AddValidatedMinorBlockHeader(data.MinorBlockHeader.Hash(), data.CoinbaseAmountMap)
 	m.master.UpdateShardStatus(data.ShardStats)
-	m.mu.Unlock()
+	m.master.UpdateTxCountHistory(data.TxCount, data.XShardTxCount, data.MinorBlockHeader.Time)
 
 	rsp := new(rpc.AddMinorBlockHeaderResponse)
 	rsp.ArtificialTxConfig = m.master.artificialTxConfig
@@ -62,11 +48,9 @@ func (m *MasterServerSideOp) AddMinorBlockHeaderList(ctx context.Context, req *r
 	if err := serialize.DeserializeFromBytes(req.Data, gReq); err != nil {
 		return nil, err
 	}
-	m.mu.Lock()
 	for _, header := range gReq.MinorBlockHeaderList {
-		m.addValidatedMinorBlockHeader(header, header.CoinbaseAmount)
+		m.master.rootBlockChain.AddValidatedMinorBlockHeader(header.Hash(), header.CoinbaseAmount)
 	}
-	m.mu.Unlock()
 	return &rpc.Response{RpcId: req.RpcId}, nil
 }
 

--- a/cluster/master/master_grpc.go
+++ b/cluster/master/master_grpc.go
@@ -3,8 +3,9 @@ package master
 import (
 	"context"
 	"sync"
-	
+
 	"github.com/QuarkChain/goquarkchain/cluster/rpc"
+	"github.com/QuarkChain/goquarkchain/core/types"
 	"github.com/QuarkChain/goquarkchain/serialize"
 )
 
@@ -21,14 +22,27 @@ func NewServerSideOp(master *QKCMasterBackend) *MasterServerSideOp {
 	}
 }
 
+// addValidatedMinorBlockHeader records a header once. The caller must hold m.mu.
+func (m *MasterServerSideOp) addValidatedMinorBlockHeader(header *types.MinorBlockHeader, coinbaseAmount *types.TokenBalances) bool {
+	hash := header.Hash()
+	if m.master.rootBlockChain.IsMinorBlockValidated(hash) {
+		return false
+	}
+	m.master.rootBlockChain.AddValidatedMinorBlockHeader(hash, coinbaseAmount)
+	return true
+}
+
 func (m *MasterServerSideOp) AddMinorBlockHeader(ctx context.Context, req *rpc.Request) (*rpc.Response, error) {
 	data := new(rpc.AddMinorBlockHeaderRequest)
 	if err := serialize.DeserializeFromBytes(req.Data, data); err != nil {
 		return nil, err
 	}
-	m.master.rootBlockChain.AddValidatedMinorBlockHeader(data.MinorBlockHeader.Hash(), data.CoinbaseAmountMap)
+	m.mu.Lock()
+	if m.addValidatedMinorBlockHeader(data.MinorBlockHeader, data.CoinbaseAmountMap) {
+		m.master.UpdateTxCountHistory(data.TxCount, data.XShardTxCount, data.MinorBlockHeader.Time)
+	}
 	m.master.UpdateShardStatus(data.ShardStats)
-	m.master.UpdateTxCountHistory(data.TxCount, data.XShardTxCount, data.MinorBlockHeader.Time)
+	m.mu.Unlock()
 
 	rsp := new(rpc.AddMinorBlockHeaderResponse)
 	rsp.ArtificialTxConfig = m.master.artificialTxConfig
@@ -48,9 +62,11 @@ func (m *MasterServerSideOp) AddMinorBlockHeaderList(ctx context.Context, req *r
 	if err := serialize.DeserializeFromBytes(req.Data, gReq); err != nil {
 		return nil, err
 	}
+	m.mu.Lock()
 	for _, header := range gReq.MinorBlockHeaderList {
-		m.master.rootBlockChain.AddValidatedMinorBlockHeader(header.Hash(), header.CoinbaseAmount)
+		m.addValidatedMinorBlockHeader(header, header.CoinbaseAmount)
 	}
+	m.mu.Unlock()
 	return &rpc.Response{RpcId: req.RpcId}, nil
 }
 

--- a/cluster/shard/api_backend.go
+++ b/cluster/shard/api_backend.go
@@ -305,11 +305,10 @@ func (s *ShardBackend) NewMinorBlock(peerId string, block *types.MinorBlock) (er
 	if s.mBPool.getBlockInPool(mHash) {
 		return
 	}
-	if s.MinorBlockChain.HasBlock(block.Hash()) {
-		log.Debug("add minor block, Known minor block", "branch", block.Branch(), "height", block.Number())
+	if s.MinorBlockChain.HasBlock(mHash) {
+		log.Debug("add minor block, known minor block", "branch", block.Branch(), "height", block.Number())
 		return
 	}
-
 	if !s.MinorBlockChain.HasBlock(block.ParentHash()) {
 		log.Debug("prarent block hash not be included", "parent hash: ", block.ParentHash().Hex())
 		return
@@ -334,7 +333,7 @@ func (s *ShardBackend) NewMinorBlock(peerId string, block *types.MinorBlock) (er
 		return nil
 	}
 
-	if err := s.MinorBlockChain.Validator().ValidateBlock(block, false); err != nil {
+	if err := s.MinorBlockChain.Validator().ValidateBlock(block, true); err != nil {
 		log.Warn(s.logInfo+" ValidateBlock", "err", err)
 		return nil // next time to handle
 	}
@@ -359,13 +358,9 @@ func (s *ShardBackend) AddMinorBlock(block *types.MinorBlock) error {
 	defer s.mu.Unlock()
 	s.wg.Add(1)
 	defer s.wg.Done()
-	if commitStatus := s.getBlockCommitStatusByHash(block.Hash()); commitStatus == BLOCK_COMMITTED {
-		return nil
-	}
-	//TODO support BLOCK_COMMITTING
 	currHead := s.MinorBlockChain.CurrentBlock().Header()
 	log.Debug(s.logInfo, "currHead", currHead.Number)
-	_, xshardLst, err := s.MinorBlockChain.InsertChainForDeposits([]types.IBlock{block}, false)
+	_, xshardLst, err := s.MinorBlockChain.InsertChainForDeposits([]types.IBlock{block}, true)
 	if err != nil {
 		log.Error(s.logInfo+" Failed to add minor block", "err", err, "len", len(xshardLst))
 		return err
@@ -385,14 +380,15 @@ func (s *ShardBackend) AddMinorBlock(block *types.MinorBlock) error {
 		return nil
 	}
 
-	prevRootHeight := s.MinorBlockChain.GetRootBlockByHash(block.PrevRootBlockHash()).Number()
-	if err := s.conn.BroadcastXshardTxList(block, xshardLst[0], prevRootHeight); err != nil {
-		s.setHead(currHead.Number)
+	prevRoot := s.MinorBlockChain.GetRootBlockByHash(block.PrevRootBlockHash())
+	if prevRoot == nil {
+		return fmt.Errorf("previous root block %s is missing", block.PrevRootBlockHash().Hex())
+	}
+	if err := s.conn.BroadcastXshardTxList(block, xshardLst[0], prevRoot.Number()); err != nil {
 		return err
 	}
 	status, err := s.MinorBlockChain.GetShardStats()
 	if err != nil {
-		s.setHead(currHead.Number)
 		return err
 	}
 
@@ -405,17 +401,14 @@ func (s *ShardBackend) AddMinorBlock(block *types.MinorBlock) error {
 	}
 	err = s.conn.SendMinorBlockHeaderToMaster(requests)
 	if err != nil {
-		s.setHead(currHead.Number)
 		return err
 	}
-	s.MinorBlockChain.CommitMinorBlockByHash(block.Hash())
 	if s.MinorBlockChain.CurrentBlock().Hash() != currHead.Hash() {
 		go s.miner.HandleNewTip()
 	}
 	// block has been added to local state, broadcast tip so that peers can sync if needed
 	if currHead.Hash() != s.MinorBlockChain.CurrentBlock().Hash() {
 		if err = s.broadcastNewTip(); err != nil {
-			s.setHead(currHead.Number)
 			return err
 		}
 	}
@@ -446,13 +439,9 @@ func (s *ShardBackend) AddBlockListForSync(blockLst []*types.MinorBlock) error {
 	for _, block := range blockLst {
 		blockHash := block.Hash()
 		if block.Branch().Value != s.branch.Value {
-			continue
+			return fmt.Errorf("sync block branch %d does not match shard branch %d", block.Branch().Value, s.branch.Value)
 		}
-		if s.getBlockCommitStatusByHash(blockHash) == BLOCK_COMMITTED {
-			continue
-		}
-		//TODO:support BLOCK_COMMITTING
-		_, xshardLst, err := s.MinorBlockChain.InsertChainForDeposits([]types.IBlock{block}, false)
+		_, xshardLst, err := s.MinorBlockChain.InsertChainForDeposits([]types.IBlock{block}, true)
 		if err != nil {
 			log.Error(s.logInfo+" Failed to add minor block", "err", err)
 			return err
@@ -462,8 +451,11 @@ func (s *ShardBackend) AddBlockListForSync(blockLst []*types.MinorBlock) error {
 			return nil
 		}
 		s.mBPool.delBlockInPool(block.Hash())
-		prevRootHeight := s.MinorBlockChain.GetRootBlockByHash(block.PrevRootBlockHash())
-		blockHashToXShardList[blockHash] = &XshardListTuple{XshardTxList: xshardLst[0], PrevRootHeight: prevRootHeight.Number()}
+		prevRoot := s.MinorBlockChain.GetRootBlockByHash(block.PrevRootBlockHash())
+		if prevRoot == nil {
+			return fmt.Errorf("previous root block %s is missing", block.PrevRootBlockHash().Hex())
+		}
+		blockHashToXShardList[blockHash] = &XshardListTuple{XshardTxList: xshardLst[0], PrevRootHeight: prevRoot.Number()}
 		uncommittedBlockHeaderList = append(uncommittedBlockHeaderList, block.Header())
 	}
 	// interrupt the current miner and restart
@@ -476,10 +468,6 @@ func (s *ShardBackend) AddBlockListForSync(blockLst []*types.MinorBlock) error {
 	}
 	if err := s.conn.SendMinorBlockHeaderListToMaster(req); err != nil {
 		return err
-	}
-	for _, header := range uncommittedBlockHeaderList {
-		s.MinorBlockChain.CommitMinorBlockByHash(header.Hash())
-		s.mBPool.delBlockInPool(header.Hash())
 	}
 	return nil
 }
@@ -535,16 +523,6 @@ func (s *ShardBackend) broadcastNewTip() (err error) {
 
 	err = s.conn.BroadcastNewTip([]*types.MinorBlockHeader{minorTip}, rootTip.Header(), s.branch.Value)
 	return
-}
-
-func (s *ShardBackend) setHead(head uint64) {
-	// TODO: This compensation rewind deletes block bodies but may leave stale
-	// transaction lookup entries. Clean up the rolled-back blocks here instead
-	// of adding unconditional index deletion to MinorBlockChain.SetHead, which is
-	// also used by reorg and recovery paths.
-	if err := s.MinorBlockChain.SetHead(head); err != nil {
-		panic(err)
-	}
 }
 
 func (s *ShardBackend) AddTxList(txs []*types.Transaction) error {
@@ -616,7 +594,7 @@ func (s *ShardBackend) CheckMinorBlock(header *types.MinorBlockHeader) error {
 	if header.Number == 0 {
 		return nil
 	}
-	_, _, err := s.MinorBlockChain.InsertChainForDeposits([]types.IBlock{block}, true)
+	err := s.MinorBlockChain.CheckMinorBlock([]types.IBlock{block})
 	return err
 }
 

--- a/cluster/shard/api_backend.go
+++ b/cluster/shard/api_backend.go
@@ -416,12 +416,8 @@ func (s *ShardBackend) AddMinorBlock(block *types.MinorBlock) error {
 	return nil
 }
 
-// Add blocks in batch to reduce RPCs. Will NOT broadcast to peers.
-//
-// Returns true if blocks are successfully added. False on any error.
-// This function only adds blocks to local and propagate xshard list to other shards.
-// It does NOT notify master because the master should already have the minor header list,
-// and will add them once this function returns successfully.
+// Add blocks in batch to reduce RPCs. It does not broadcast minor blocks to
+// peers, but it broadcasts their x-shard lists and submits their headers to master.
 func (s *ShardBackend) AddBlockListForSync(blockLst []*types.MinorBlock) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/cluster/shard/api_backend.go
+++ b/cluster/shard/api_backend.go
@@ -333,7 +333,7 @@ func (s *ShardBackend) NewMinorBlock(peerId string, block *types.MinorBlock) (er
 		return nil
 	}
 
-	if err := s.MinorBlockChain.Validator().ValidateBlock(block, true); err != nil {
+	if err := s.MinorBlockChain.Validator().ValidateBlock(block, false); err != nil {
 		log.Warn(s.logInfo+" ValidateBlock", "err", err)
 		return nil // next time to handle
 	}

--- a/cluster/shard/shard.go
+++ b/cluster/shard/shard.go
@@ -28,14 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-type BlockCommitCode int
-
-const (
-	BLOCK_UNCOMMITTED BlockCommitCode = iota
-	BLOCK_COMMITTING                  // TODO not support yet,need discuss
-	BLOCK_COMMITTED
-)
-
 type ShardBackend struct {
 	Config            *config.ShardConfig
 	branch            account.Branch
@@ -204,22 +196,6 @@ func (s *ShardBackend) initGenesisState(rootBlock *types.RootBlock) error {
 		CoinbaseAmountMap: minorBlock.CoinbaseAmount(),
 	}
 	return s.conn.SendMinorBlockHeaderToMaster(request)
-}
-
-func (s *ShardBackend) getBlockCommitStatusByHash(blockHash common.Hash) BlockCommitCode {
-	// If the block is committed, it means
-	// - All neighbor shards/slaves receives x-shard tx list
-	// - The block header is sent to master
-	// then return immediately
-	if s.MinorBlockChain.IsMinorBlockCommittedByHash(blockHash) {
-		return BLOCK_COMMITTED
-	}
-
-	//TODO support BLOCK_COMMITTING???
-
-	// Check if the block is being propagating to other slaves and the master
-	// Let's make sure all the shards and master got it before committing it
-	return BLOCK_UNCOMMITTED
 }
 
 // minor block pool

--- a/cluster/slave/api_backend.go
+++ b/cluster/slave/api_backend.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sort"
 
 	"github.com/QuarkChain/goquarkchain/account"
 	"github.com/QuarkChain/goquarkchain/cluster/rpc"
@@ -20,6 +21,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"golang.org/x/sync/errgroup"
 )
+
+const BlockBatchSize = 100
 
 func (s *SlaveBackend) GetUnconfirmedHeaderList() ([]*rpc.HeadersInfo, error) {
 	var (
@@ -96,37 +99,44 @@ func (s *SlaveBackend) AddBlockListForSync(mHashList []common.Hash, peerId strin
 		return nil, ErrMsg("AddBlockListForSync")
 	}
 
+	blockList := make([]*types.MinorBlock, 0, len(mHashList))
 	hashList := make([]common.Hash, 0, len(mHashList))
 	for _, hash := range mHashList {
-		if !shard.MinorBlockChain.HasBlock(hash) {
+		block := shard.MinorBlockChain.GetMinorBlock(hash)
+		if block == nil {
 			hashList = append(hashList, hash)
+		} else {
+			blockList = append(blockList, block)
 		}
 	}
 
-	var (
-		BlockBatchSize = 100
-		tHashList      []common.Hash
-	)
 	for len(hashList) > 0 {
 		hLen := BlockBatchSize
-		if len(hashList) > BlockBatchSize {
-			tHashList = hashList[:BlockBatchSize]
-		} else {
-			tHashList = hashList
+		if len(hashList) < hLen {
 			hLen = len(hashList)
 		}
-		bList, err := s.connManager.GetMinorBlocks(tHashList, peerId, branch)
+		hashBatch := hashList[:hLen]
+		blocks, err := s.connManager.GetMinorBlocks(hashBatch, peerId, branch)
 		if err != nil {
 			log.Error("Failed to sync request from master", "branch", branch, "peer-id", peerId, "err", err)
 			return nil, err
 		}
-		if len(bList) != hLen {
-			return nil, errors.New("Failed to add minor blocks for syncing root block: length of downloaded block list is incorrect")
+		if len(blocks) != len(hashBatch) {
+			return nil, errors.New("failed to add minor blocks for syncing root block: downloaded block count does not match request")
 		}
-		if err := shard.AddBlockListForSync(bList); err != nil {
-			return nil, err
+		for i, block := range blocks {
+			if block == nil || block.Hash() != hashBatch[i] {
+				return nil, fmt.Errorf("downloaded minor block does not match requested hash at index %d", i)
+			}
 		}
+		blockList = append(blockList, blocks...)
 		hashList = hashList[hLen:]
+	}
+	sort.Slice(blockList, func(i, j int) bool {
+		return blockList[i].NumberU64() < blockList[j].NumberU64()
+	})
+	if err := shard.AddBlockListForSync(blockList); err != nil {
+		return nil, err
 	}
 	return shard.MinorBlockChain.GetShardStats()
 }

--- a/cluster/sync/root_task.go
+++ b/cluster/sync/root_task.go
@@ -240,6 +240,9 @@ func (r *rootChainTask) syncMinorBlocks(
 	downloadMap := make(map[uint32][]common.Hash)
 	for _, header := range rootBlock.MinorBlockHeaders() {
 		hash := header.Hash()
+		if rbc.IsMinorBlockValidated(hash) {
+			continue
+		}
 		downloadMap[header.Branch.Value] = append(downloadMap[header.Branch.Value], hash)
 	}
 

--- a/cluster/sync/root_task_test.go
+++ b/cluster/sync/root_task_test.go
@@ -311,14 +311,24 @@ func TestSyncMinorBlocks(t *testing.T) {
 	defer ctrl.Finish()
 	shardConns := newFakeConnManager(1, ctrl)
 	for _, block := range blocks {
-		for _, header := range block.MinorBlockHeaders() {
+		headers := block.MinorBlockHeaders()
+		rbc.AddValidatedMinorBlockHeader(headers[0].Hash(), headers[0].CoinbaseAmount)
+		for _, header := range headers[1:] {
 			if rbc.IsMinorBlockValidated(header.Hash()) {
 				t.Errorf("validated minor block hash in block %d is exist", block.NumberU64())
 			}
 		}
 
 		AddBlockListForSyncFunc := func(request *rpc.AddBlockListForSyncRequest) (*rpc.ShardStatus, error) {
-			for _, header := range block.MinorBlockHeaders() {
+			if len(request.MinorBlockHashList) != len(headers)-1 {
+				t.Fatalf("minor hash list length = %d, want %d", len(request.MinorBlockHashList), len(headers)-1)
+			}
+			for i, hash := range request.MinorBlockHashList {
+				if hash != headers[i+1].Hash() {
+					t.Fatalf("minor hash at %d = %s, want %s", i, hash.Hex(), headers[i+1].Hash().Hex())
+				}
+			}
+			for _, header := range headers[1:] {
 				rbc.AddValidatedMinorBlockHeader(header.Hash(), header.CoinbaseAmount)
 			}
 			return &rpc.ShardStatus{

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -275,7 +275,6 @@ func (g *Genesis) CommitMinorBlock(db ethdb.Database, rootBlock *types.RootBlock
 	if qkcConfig == nil {
 		qkcConfig = config.NewQuarkChainConfig()
 	}
-	rawdb.WriteCommitMinorBlock(db, block.Hash())
 	rawdb.WriteChainConfig(db, block.Hash(), qkcConfig)
 	return block, nil
 }

--- a/core/minorblockchain.go
+++ b/core/minorblockchain.go
@@ -262,7 +262,11 @@ func (m *MinorBlockChain) AddBlock(block types.IBlock) error {
 	if !ok {
 		return errors.New("block is not minorBlock")
 	}
-	return m.addMinorBlockAndBroad(minorBlock)
+	handler := m.addMinorBlockAndBroad
+	if handler == nil {
+		panic("minor block handler is not configured")
+	}
+	return handler(minorBlock)
 }
 
 func (m *MinorBlockChain) getProcInterrupt() bool {
@@ -303,10 +307,8 @@ func (m *MinorBlockChain) loadLastState() error {
 	return nil
 }
 
-// SetHead rewinds the local chain to a new head. In the case of Headers, everything
-// above the new head will be deleted and the new one set. In the case of blocks
-// though, the head may be further rewound if block bodies are missing (non-archive
-// nodes after a fast sync).
+// SetHead rewinds the local chain to a new head and deletes block bodies above it.
+// Canonical reorgs use reorg instead, which retains bodies for later reuse.
 // Locks are acquired in chainmu -> mu order, matching the block import path.
 func (m *MinorBlockChain) SetHead(head uint64) error {
 	m.chainmu.Lock()
@@ -319,7 +321,7 @@ func (m *MinorBlockChain) SetHead(head uint64) error {
 func (m *MinorBlockChain) setHead(head uint64) error {
 	log.Warn(m.logInfo+" Rewinding blockchain", "target", head)
 	defer log.Warn(m.logInfo+" Rewinding blockchain-end", "target number", head)
-	// Rewind the header chain, deleting all block bodies until then
+	// Rewind the chain, deleting block bodies and canonical mappings.
 	batch := m.db.NewBatch()
 	for block := m.CurrentBlock(); block != nil && block.NumberU64() > head; block = m.CurrentBlock() {
 		rawdb.DeleteMinorBlock(batch, block.Hash())
@@ -553,9 +555,9 @@ func (m *MinorBlockChain) Genesis() *types.MinorBlock {
 	return m.genesisBlock
 }
 
-// HasBlock checks if a block is fully present in the database or not.
+// HasBlock checks whether the block body is present in the database.
 func (m *MinorBlockChain) HasBlock(hash common.Hash) bool {
-	return m.IsMinorBlockCommittedByHash(hash)
+	return rawdb.HasBlock(m.db, hash)
 }
 
 // HasState checks if state trie is fully present in the database or not.
@@ -734,10 +736,19 @@ func (m *MinorBlockChain) procFutureBlocks() {
 		}
 	}
 	if len(blocks) > 0 {
+		handler := m.addMinorBlockAndBroad
+		if handler == nil {
+			// A shard must install the handler before future-block processing starts.
+			// Retrying or falling back to a core-only insert would skip x-shard and
+			// master-header propagation and leave the block only partially handled.
+			panic("minor block handler is not configured")
+		}
 		sort.Slice(blocks, func(i, j int) bool { return blocks[i].NumberU64() < blocks[j].NumberU64() })
-		// Insert one by one as chain insertion needs contiguous ancestry between blocks
+		// Use the shard entry point so x-shard lists and headers are sent too.
 		for i := range blocks {
-			m.InsertChain(blocks[i:i+1], false)
+			if err := handler(blocks[i].(*types.MinorBlock)); err != nil {
+				log.Warn(m.logInfo+" failed to process future block", "number", blocks[i].NumberU64(), "hash", blocks[i].Hash(), "err", err)
+			}
 		}
 	}
 }
@@ -1006,7 +1017,6 @@ func (m *MinorBlockChain) WriteBlockWithState(block *types.MinorBlock, receipts 
 	if status == CanonStatTy {
 		m.insert(block)
 	}
-	m.CommitMinorBlockByHash(block.Hash())
 	m.futureBlocks.Remove(block.Hash())
 	return status, nil
 }
@@ -1029,14 +1039,15 @@ func (m *MinorBlockChain) addFutureBlock(block types.IBlock) error {
 // wrong.
 //
 // After insertion is done, all accumulated events will be fired.
-func (m *MinorBlockChain) InsertChain(chain []types.IBlock, isCheckDB bool) (int, error) {
-	n, _, err := m.InsertChainForDeposits(chain, isCheckDB)
+func (m *MinorBlockChain) InsertChain(chain []types.IBlock, force bool) (int, error) {
+	n, _, err := m.InsertChainForDeposits(chain, force)
 	return n, err
 }
 
 // InsertChainForDeposits also return cross-shard transaction deposits in addition
-// to content returned from `InsertChain`.
-func (m *MinorBlockChain) InsertChainForDeposits(chain []types.IBlock, isCheckDB bool) (int, [][]*types.CrossShardTransactionDeposit, error) {
+// to content returned from `InsertChain`. When force is true, known blocks are
+// executed and inserted again through the normal tip-selection path.
+func (m *MinorBlockChain) InsertChainForDeposits(chain []types.IBlock, force bool) (int, [][]*types.CrossShardTransactionDeposit, error) {
 	// Sanity check that we have something meaningful to import
 	if len(chain) == 0 {
 		return 0, nil, nil
@@ -1055,7 +1066,7 @@ func (m *MinorBlockChain) InsertChainForDeposits(chain []types.IBlock, isCheckDB
 	// Pre-checks passed, start the full block imports
 	m.wg.Add(1)
 	m.chainmu.Lock()
-	n, events, logs, xShardList, err := m.insertChain(chain, true, isCheckDB)
+	n, events, logs, xShardList, err := m.insertChain(chain, true, force, false)
 	m.chainmu.Unlock()
 	m.wg.Done()
 
@@ -1072,6 +1083,20 @@ func (m *MinorBlockChain) InsertChainForDeposits(chain []types.IBlock, isCheckDB
 	return n, xShardList, err
 }
 
+// CheckMinorBlock validates and executes a chain without persisting it
+// or changing the canonical head. It is used by header validation paths.
+func (m *MinorBlockChain) CheckMinorBlock(chain []types.IBlock) error {
+	if len(chain) == 0 {
+		return nil
+	}
+	m.wg.Add(1)
+	defer m.wg.Done()
+	m.chainmu.Lock()
+	defer m.chainmu.Unlock()
+	_, _, _, _, err := m.insertChain(chain, true, true, true)
+	return err
+}
+
 // insertChain is the internal implementation of insertChain, which assumes that
 // 1) chains are contiguous, and 2) The chain mutex is held.
 //
@@ -1080,7 +1105,7 @@ func (m *MinorBlockChain) InsertChainForDeposits(chain []types.IBlock, isCheckDB
 // racey behaviour. If a sidechain import is in progress, and the historic state
 // is imported, but then new canon-head is added before the actual sidechain
 // completes, then the historic state could be pruned again
-func (m *MinorBlockChain) insertChain(chain []types.IBlock, verifySeals bool, isCheckDB bool) (int, []interface{}, []*types.Log, [][]*types.CrossShardTransactionDeposit, error) {
+func (m *MinorBlockChain) insertChain(chain []types.IBlock, verifySeals bool, force bool, readOnly bool) (int, []interface{}, []*types.Log, [][]*types.CrossShardTransactionDeposit, error) {
 	xShardList := make([][]*types.CrossShardTransactionDeposit, 0)
 	// If the chain is terminating, don't even bother starting u
 	if atomic.LoadInt32(&m.procInterrupt) == 1 {
@@ -1104,12 +1129,12 @@ func (m *MinorBlockChain) insertChain(chain []types.IBlock, verifySeals bool, is
 	)
 
 	// Peek the error for the first block to decide the directing import logic
-	it := newInsertIterator(chain, m.Validator(), isCheckDB)
+	it := newInsertIterator(chain, m.Validator(), force)
 	block, err := it.next()
 	switch {
 	// First block is pruned, insert as sidechain and reorg only if TD grows enough
 	case err == ErrPrunedAncestor:
-		return m.insertSidechain(it, isCheckDB)
+		return m.insertSidechain(it, force, readOnly)
 
 	// First block is future, shove it (and all children) to the future queue (unknown ancestor)
 	case err == ErrFutureBlock || (err == ErrUnknownAncestor && m.futureBlocks.Contains(it.first().ParentHash())):
@@ -1175,9 +1200,9 @@ func (m *MinorBlockChain) insertChain(chain []types.IBlock, verifySeals bool, is
 			return it.index, events, coalescedLogs, xShardList, err
 		}
 
-		if isCheckDB {
+		if readOnly {
 			xShardList = append(xShardList, state.GetXShardList())
-			return 0, events, coalescedLogs, xShardList, nil
+			continue
 		}
 		updateTip, err := m.updateTip(state, mBlock)
 		if err != nil {
@@ -1241,7 +1266,7 @@ func (m *MinorBlockChain) insertChain(chain []types.IBlock, verifySeals bool, is
 //
 // The method writes all (header-and-body-valid) blocks to disk, then tries to
 // switch over to the new chain if the TD exceeded the current chain.
-func (m *MinorBlockChain) insertSidechain(it *insertIterator, isCheckDB bool) (int, []interface{}, []*types.Log, [][]*types.CrossShardTransactionDeposit, error) {
+func (m *MinorBlockChain) insertSidechain(it *insertIterator, force bool, readOnly bool) (int, []interface{}, []*types.Log, [][]*types.CrossShardTransactionDeposit, error) {
 	var (
 		current      = m.CurrentBlock().NumberU64()
 		externHeight = uint64(0)
@@ -1276,7 +1301,6 @@ func (m *MinorBlockChain) insertSidechain(it *insertIterator, isCheckDB bool) (i
 			if err := m.WriteBlockWithoutState(block); err != nil {
 				return it.index, nil, nil, nil, err
 			}
-			m.CommitMinorBlockByHash(block.Hash())
 			log.Debug("Inserted sidechain block", "number", block.NumberU64(), "hash", block.Hash(),
 				"diff", block.IHeader().GetDifficulty(), "elapsed", common.PrettyDuration(time.Since(start)),
 				"txs", len(block.(*types.MinorBlock).GetTransactions()), "gas", block.(*types.MinorBlock).GetMetaData().GasUsed,
@@ -1323,7 +1347,7 @@ func (m *MinorBlockChain) insertSidechain(it *insertIterator, isCheckDB bool) (i
 		// memory here.
 		if len(blocks) >= 2048 || memory > 64*1024*1024 {
 			log.Info("Importing heavy sidechain segment", "blocks", len(blocks), "start", blocks[0].NumberU64(), "end", block.NumberU64())
-			if _, _, _, _, err := m.insertChain(blocks, false, isCheckDB); err != nil {
+			if _, _, _, _, err := m.insertChain(blocks, false, force, readOnly); err != nil {
 				return 0, nil, nil, nil, err
 			}
 			blocks, memory = blocks[:0], 0
@@ -1337,7 +1361,7 @@ func (m *MinorBlockChain) insertSidechain(it *insertIterator, isCheckDB bool) (i
 	}
 	if len(blocks) > 0 {
 		log.Info("Importing sidechain segment", "start", blocks[0].NumberU64(), "end", blocks[len(blocks)-1].NumberU64())
-		return m.insertChain(blocks, false, isCheckDB)
+		return m.insertChain(blocks, false, force, readOnly)
 	}
 	return 0, nil, nil, nil, nil
 }
@@ -1433,12 +1457,9 @@ func (m *MinorBlockChain) reorg(oldBlock, newBlock types.IBlock) error {
 		}
 
 	} else {
-		// we support reorg block from same chain,because we should delete and add tx index
+		// Same-chain rewinds retain bodies and only rewrite canonical indexes.
 		log.Warn(m.logInfo+" reorg", "same chain curr", m.CurrentBlock().NumberU64(), "curr.Hash", m.CurrentBlock().Hash().TerminalString(),
 			"newBlock", newBlockNumber, "newBlock's hash", newBlockHash, "newBlock", m.GetMinorBlock(newBlockHash) == nil)
-		if err := m.setHead(newBlockNumber); err != nil {
-			return err
-		}
 	}
 
 	// When transactions get deleted from the database that means the
@@ -1448,9 +1469,15 @@ func (m *MinorBlockChain) reorg(oldBlock, newBlock types.IBlock) error {
 		if err := m.removeTxIndexFromBlock(batch, oldChain[i].(*types.MinorBlock)); err != nil {
 			return err
 		}
+		rawdb.DeleteCanonicalHash(batch, rawdb.ChainTypeMinor, oldChain[i].NumberU64())
 	}
 
-	batch.Write()
+	if err := batch.Write(); err != nil {
+		return err
+	}
+	if len(newChain) == 0 {
+		m.insert(newBlock.(*types.MinorBlock))
+	}
 
 	// Insert the new chain, taking care of the proper incremental order
 	for i := len(newChain) - 1; i >= 0; i-- {

--- a/core/minorblockchain.go
+++ b/core/minorblockchain.go
@@ -1328,7 +1328,7 @@ func (m *MinorBlockChain) insertSidechain(it *insertIterator, force bool, readOn
 
 		parent = m.GetBlock(parent.ParentHash())
 	}
-	if parent == nil {
+	if qkcCommon.IsNil(parent) {
 		return it.index, nil, nil, nil, errors.New("missing parent")
 	}
 	// Import all the pruned blocks to make the state available

--- a/core/minorblockchain_addon.go
+++ b/core/minorblockchain_addon.go
@@ -350,7 +350,6 @@ func (m *MinorBlockChain) InitGenesisState(rBlock *types.RootBlock) (*types.Mino
 	}
 	m.putRootBlock(rBlock, nil)
 	rawdb.WriteGenesisBlock(m.db, rBlock.Hash(), gBlock) // key:rootBlockHash value:minorBlock
-	m.CommitMinorBlockByHash(gBlock.Hash())
 	if m.initialized {
 		return gBlock, nil
 	}
@@ -1021,8 +1020,11 @@ func (m *MinorBlockChain) AddRootBlock(rBlock *types.RootBlock) (bool, error) {
 		prevRootBlock := m.GetRootBlockByHash(mHeader.PrevRootBlockHash)
 
 		// prev_root_header can be None when the shard is not created at root height 0
-		t := prevRootBlock.Number()
-		if prevRootBlock == nil || prevRootBlock.Number() == uint32(m.clusterConfig.Quarkchain.GetGenesisRootHeight(m.branch.Value)) || !m.isNeighbor(mHeader.Branch, &t) {
+		var prevRootHeight uint32
+		if prevRootBlock != nil {
+			prevRootHeight = prevRootBlock.Number()
+		}
+		if prevRootBlock == nil || prevRootHeight == uint32(m.clusterConfig.Quarkchain.GetGenesisRootHeight(m.branch.Value)) || !m.isNeighbor(mHeader.Branch, &prevRootHeight) {
 			if data := m.ReadCrossShardTxList(h); data != nil {
 				errXshardListAlreadyHave := errors.New("already have")
 				log.Error(m.logInfo, "addrootBlock err-1", errXshardListAlreadyHave)
@@ -1876,14 +1878,6 @@ func (m *MinorBlockChain) putXShardDepositHashList(h common.Hash, hList *rawdb.H
 
 func (m *MinorBlockChain) getXShardDepositHashList(h common.Hash) *rawdb.HashList {
 	return rawdb.GetXShardDepositHashList(m.db, h)
-}
-
-func (m *MinorBlockChain) IsMinorBlockCommittedByHash(h common.Hash) bool {
-	return rawdb.HasCommitMinorBlock(m.db, h)
-}
-
-func (m *MinorBlockChain) CommitMinorBlockByHash(h common.Hash) {
-	rawdb.WriteCommitMinorBlock(m.db, h)
 }
 
 func (m *MinorBlockChain) GetMiningInfo(address account.Recipient, stake *types.TokenBalances) (mineable, mined uint64, err error) {

--- a/core/minorblockchain_test.go
+++ b/core/minorblockchain_test.go
@@ -93,6 +93,92 @@ func newMinorCanonical(cacheConfig *CacheConfig, engine consensus.Engine, n int,
 	return db, blockchain, err
 }
 
+func TestMinorSetHeadDeletesBlockBodies(t *testing.T) {
+	_, blockchain, err := newMinorCanonical(nil, new(consensus.FakeEngine), 3, true)
+	if err != nil {
+		t.Fatalf("create canonical chain: %v", err)
+	}
+	defer blockchain.Stop()
+
+	block2 := blockchain.GetBlockByNumber(2).(*types.MinorBlock)
+	block3 := blockchain.GetBlockByNumber(3).(*types.MinorBlock)
+	if err := blockchain.SetHead(1); err != nil {
+		t.Fatalf("SetHead: %v", err)
+	}
+	if blockchain.GetBlockByNumber(2) != nil || blockchain.GetBlockByNumber(3) != nil {
+		t.Fatal("rewound blocks must not remain canonical")
+	}
+	if blockchain.GetMinorBlock(block2.Hash()) != nil || blockchain.GetMinorBlock(block3.Hash()) != nil {
+		t.Fatal("SetHead must delete rewound block bodies")
+	}
+}
+
+func TestMinorSameChainReorgRetainsBodies(t *testing.T) {
+	db, blockchain, err := newMinorCanonical(nil, new(consensus.FakeEngine), 3, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer blockchain.Stop()
+
+	block1 := blockchain.GetBlockByNumber(1).(*types.MinorBlock)
+	block2 := blockchain.GetBlockByNumber(2).(*types.MinorBlock)
+	block3 := blockchain.GetBlockByNumber(3).(*types.MinorBlock)
+	if err := blockchain.reorg(block3, block1); err != nil {
+		t.Fatalf("same-chain reorg: %v", err)
+	}
+	if blockchain.GetMinorBlock(block2.Hash()) == nil || blockchain.GetMinorBlock(block3.Hash()) == nil {
+		t.Fatal("reorg must retain displaced block bodies")
+	}
+	if blockchain.GetBlockByNumber(2) != nil || blockchain.GetBlockByNumber(3) != nil {
+		t.Fatal("reorg must remove displaced canonical mappings")
+	}
+	if _, _, err := blockchain.InsertChainForDeposits([]types.IBlock{block3}, true); err != nil {
+		t.Fatalf("force insert retained block: %v", err)
+	}
+	if blockchain.CurrentBlock().Hash() != block3.Hash() {
+		t.Fatalf("force insert head = %s, want %s", blockchain.CurrentBlock().Hash().Hex(), block3.Hash().Hex())
+	}
+	if err := blockchain.reorg(block3, block1); err != nil {
+		t.Fatalf("second same-chain reorg: %v", err)
+	}
+
+	block4 := makeBlockChain(block3, 1, new(consensus.FakeEngine), db, canonicalSeed)[0]
+	if _, err := blockchain.InsertChain([]types.IBlock{block4}, false); err != nil {
+		t.Fatalf("insert child of retained chain: %v", err)
+	}
+	if blockchain.CurrentBlock().Hash() != block4.Hash() {
+		t.Fatalf("head = %s, want %s", blockchain.CurrentBlock().Hash().Hex(), block4.Hash().Hex())
+	}
+	if block := blockchain.GetBlockByNumber(2); block == nil || block.Hash() != block2.Hash() {
+		t.Fatal("inserting the child must restore intermediate canonical mappings")
+	}
+}
+
+func TestProcFutureBlocksUsesShardCallback(t *testing.T) {
+	db, blockchain, err := newMinorCanonical(nil, new(consensus.FakeEngine), 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer blockchain.Stop()
+
+	block := makeBlockChain(blockchain.CurrentBlock(), 1, new(consensus.FakeEngine), db, canonicalSeed)[0]
+	called := 0
+	blockchain.SetBroadcastMinorBlockFunc(func(got *types.MinorBlock) error {
+		called++
+		if got.Hash() != block.Hash() {
+			t.Fatalf("callback block = %s, want %s", got.Hash().Hex(), block.Hash().Hex())
+		}
+		return nil
+	})
+	blockchain.futureBlocks.Add(block.Hash(), block)
+
+	blockchain.procFutureBlocks()
+
+	if called != 1 {
+		t.Fatalf("callback called %d times, want 1", called)
+	}
+}
+
 // TestMinor fork of length N starting from block i
 func testMinorFork(t *testing.T, blockchain *MinorBlockChain, i, n int, full bool, comparator func(td1, td2 *big.Int)) {
 	// Copy old chain up to #i into a new db
@@ -166,7 +252,6 @@ func testMinorBlockChainImport(chain []types.IBlock, blockchain *MinorBlockChain
 		}
 		blockchain.mu.Lock()
 		rawdb.WriteMinorBlock(blockchain.db, block.(*types.MinorBlock))
-		rawdb.WriteCommitMinorBlock(blockchain.db, block.Hash())
 		statedb.Commit(true)
 		blockchain.mu.Unlock()
 	}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -379,7 +379,6 @@ func DeleteReceipts(db DatabaseDeleter, hash common.Hash) {
 func DeleteMinorBlock(db DatabaseDeleter, hash common.Hash) {
 	DeleteReceipts(db, hash)
 	DeleteBlock(db, hash)
-	DeleteMinorBlockCommitStatus(db, hash)
 }
 
 // DeleteRootBlock removes all block data associated with a hash.
@@ -636,23 +635,4 @@ func GetXShardDepositHashList(db DatabaseReader, h common.Hash) *HashList {
 		return nil
 	}
 	return hList
-}
-
-func WriteCommitMinorBlock(db DatabaseWriter, h common.Hash) {
-	if err := db.Put(makeCommitMinorBlock(h), []byte{1}); err != nil { // value must not empty
-		log.Crit("failed to write commit minor block", "err", err)
-	}
-}
-
-func HasCommitMinorBlock(db DatabaseReader, h common.Hash) bool {
-	if has, err := db.Has(makeCommitMinorBlock(h)); !has || err != nil {
-		return false
-	}
-	return true
-}
-
-func DeleteMinorBlockCommitStatus(db DatabaseDeleter, h common.Hash) {
-	if err := db.Delete(makeCommitMinorBlock(h)); err != nil {
-		log.Crit("Failed to delete commit minor block", "err", err)
-	}
 }

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -51,7 +51,6 @@ var (
 	genesis            = []byte("genesis")
 	countMinor         = []byte("cntM") //minorBlock cnt in rootBlockChain
 	mHeader            = []byte("mhC")  //mHeader coinbase
-	commitBlockByHash  = []byte("cmB")  //CommittedMinorBlock
 	xsHashList         = []byte("xd")
 	mConfiredByRoot    = []byte("mr") //key:mHash value rHash
 )
@@ -177,10 +176,5 @@ func makeRootBlockConfirmingMinorBlock(mBlockID []byte) []byte {
 
 func makeXShardDepositHashList(h common.Hash) []byte {
 	data := append(xsHashList, h.Bytes()...)
-	return data
-}
-
-func makeCommitMinorBlock(h common.Hash) []byte {
-	data := append(commitBlockByHash, h.Bytes()...)
 	return data
 }

--- a/core/shardstate_test.go
+++ b/core/shardstate_test.go
@@ -3630,3 +3630,29 @@ func TestXshardGasLimitFromMultipleShards(t *testing.T) {
 	tb = shardState0.currentEvmState.GetBalance(acc1.Recipient, shardState0.GetGenesisToken())
 	assert.Equal(t, tb, big.NewInt(10000000+1000000+12345+888888+111111))
 }
+
+func TestInsertChainForDepositsForceMultiBlock(t *testing.T) {
+	env := setUp(nil, nil, nil)
+	shardState := createDefaultShardState(env, nil, nil, nil, nil)
+	defer shardState.Stop()
+
+	b1 := shardState.CurrentBlock().CreateBlockToAppend(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	b1, _, err := shardState.FinalizeAndAddBlock(b1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b2 := shardState.CurrentBlock().CreateBlockToAppend(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	b2, _, err = shardState.FinalizeAndAddBlock(b2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, xshardList, err := shardState.InsertChainForDeposits([]types.IBlock{b1, b2}, true)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(xshardList))
+
+	_, xshardList, err = shardState.InsertChainForDeposits([]types.IBlock{b1}, true)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(xshardList))
+}

--- a/core/shardstate_test.go
+++ b/core/shardstate_test.go
@@ -1931,7 +1931,11 @@ func TestResetToOldChain(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, shardState.CurrentBlock().Hash(), rs1.Hash())
 	assert.Equal(t, shardState.GetBlockByNumber(1).Hash(), rs1.Hash())
-	assert.Equal(t, shardState.GetBlockByNumber(2).Hash(), rr2.Hash())
+	assert.Nil(t, shardState.GetBlockByNumber(2))
+	retainedBlock := shardState.GetMinorBlock(rr2.Hash())
+	if assert.NotNil(t, retainedBlock) {
+		assert.Equal(t, retainedBlock.Hash(), rr2.Hash())
+	}
 }
 
 func TestContractCall(t *testing.T) {

--- a/core/shardstate_test.go
+++ b/core/shardstate_test.go
@@ -2691,13 +2691,14 @@ func TestReorg(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, shardState.CurrentBlock().Hash(), rs1.Hash())
 	assert.Equal(t, shardState.GetBlockByNumber(1).Hash(), rs1.Hash())
-	assert.Equal(t, shardState.GetBlockByNumber(2).Hash(), rr2.Hash())
+	assert.Nil(t, shardState.GetBlockByNumber(2))
+	assert.NotNil(t, shardState.GetMinorBlock(rr2.Hash()))
 
 	err = shardState.reorg(shardState.CurrentBlock(), rr1) //rr2->rr1 so rr1
 	assert.NoError(t, err)
 	assert.Equal(t, shardState.CurrentBlock().Hash(), rr1.Hash())
 	assert.Equal(t, shardState.GetBlockByNumber(1).Hash(), rr1.Hash())
-	assert.Equal(t, shardState.GetBlockByNumber(2).Hash(), rr2.Hash())
+	assert.Nil(t, shardState.GetBlockByNumber(2))
 
 	err = shardState.reorg(shardState.CurrentBlock(), rr2) //rr2->rr2 so rr2
 	assert.NoError(t, err)


### PR DESCRIPTION
# 移除 Minor Block Commit Marker

## 背景

本 PR 基于 [QuarkChain/goquarkchain#694](https://github.com/QuarkChain/goquarkchain/pull/694) 的 race condition 修复，进一步简化 minor block 的提交状态管理。

## 问题

DB 中存在 minor block body/state，只能说明 block 已经执行并写入本地，不能说明 x-shard 广播和向 master 提交 mheader 已经完成。

旧实现通过独立的 commit marker 记录 x-shard 广播和 mheader 提交是否完成。由于 marker 与 body/state 分别写入，恢复时必须组合判断两类状态；它们在崩溃、重试或并发回退时可能不一致，例如：

- insert 后发生崩溃或 RPC 失败时，可能存在 body/state，但 marker 尚未写入；
- 并发回退时，可能出现 body 已被删除，但 marker 随后仍被写入；
- 同步重试需要同时判断 body/state 和 marker，并处理两者不一致的状态。

本 PR 在 #694 修复 race condition 的基础上移除 commit marker：

- shard 根据 minor block body 是否存在决定是否下载；
- master 根据 validated mheader 是否存在决定 root sync 是否需要重新处理该 minor block。

这样不再需要维护独立 marker，也避免了 marker 与实际 block 状态不一致的问题。

## 前提条件

以下是不使用 commit marker 时，后续状态恢复和 Root Reorg 流程能够成立的前提：

1. minor block 按 parent-first 顺序插入。
2. **[本 PR 修改]** 正常 insert、root reorg 和 canonical head 切换不删除已经写入的 body。
3. shard 先广播 x-shard，再向 master 提交 mheader。
4. x-shard 数据按 minor hash 覆盖保存；master 按 minor hash 对 mheader 去重。
5. root block 引用的 minor block 全部处理成功后，才能插入该 root block。

因此：

- 不存在 block N 的 body 存在，但 block N-1 的 body 不存在。
- master 已保存 mheader 时，提交该 header 的 shard 实例仍保存对应 body，且 x-shard 已成功发送。
- 重复发送 x-shard 或 mheader 不会引入错误。
- 不会出现 root block 已插入，但其中的 minor block 尚未在 shard 正确保存的情况。

以上保证针对单 shard 实例。显式 `SetHead/reset`、数据库损坏、state pruning 和多 slave 副本需要单独处理。

## 状态与恢复方式

| Shard body | Master mheader | 状态 | 处理方式 |
|---|---|---|---|
| 不存在 | 不存在 | block 尚未处理 | minor sync 下载并处理；如果远端 root block 引用它，也可由 root sync 下载并处理 |
| 存在 | 不存在 | insert 已完成，但 x-shard 或 mheader 提交可能未完成 | root sync 复用本地 body，force 执行，重新广播 x-shard 并提交 mheader |
| 存在 | 存在 | block 已完成处理 | 无需恢复；根据处理顺序可知 x-shard 已成功发送 |
| 不存在 | 存在 | 违反方案前提 | 可能由 `SetHead/reset`、数据库损坏或多副本数据不一致导致 |

minor sync 使用 `HasBlock`，因此 body 已存在时不会重新处理。`Shard body 存在、Master mheader 不存在` 当前只通过 root sync 恢复。

## Root Reorg

root reorg 只修改 canonical mapping、交易索引和 head，不删除 minor block body。

例如从 C 回退到 A：

```text
reorg 前 canonical: A -> B -> C
reorg 后 canonical: A
本地保留 body/state: B -> C
```

### 通过新 Minor Block 恢复

收到 D，且 `D.parent = C`：

```text
AddMinorBlock(D)
-> core 沿 D -> C -> B 回溯
-> 找到 canonical ancestor A
-> 恢复 B/C/D canonical mapping
-> current head 更新为 D
```

B/C 已经完成 x-shard 广播和 mheader 提交，因此只处理新 block D。

### 通过 AddRootBlock 恢复

RootTask 收到包含 `[B, C]` 的远端 root block R：

```text
B/C 已 validated
-> 不调用 AddBlockListForSync
-> master 插入 R
-> 将 R 发送给 slave/shard
-> ShardBackend.AddRootBlock(R)
```

`ShardBackend.AddRootBlock` 从 R 中找到最后确认的 minor header C。虽然当前 canonical chain 只有 A，但本地仍保存 B/C body/state，因此可以执行：

```text
confirmedHeaderTip = C
-> 从 C 沿 parent 回溯到 A
-> 重写 B/C canonical mapping
-> current head 更新为 C
```

这种情况下 shard 可以恢复，不需要重新广播 B/C 的 x-shard，也不需要重新提交 mheader。

跨 genesis root fork 时执行 destructive genesis reset，删除旧 genesis 以上的 minor chain 数据，并从新 genesis 重新同步。该极端路径不属于普通 root reorg 保留 body 的保证范围。

## 已知边界

在 `Shard body C 已存在、Master mheader C 不存在` 的状态下，shard 可以继续插入 D，master 也可以保存 D mheader，但 master 创建 root block 时会在缺失的 C 处停止：

- 远端 root block 包含 C 时，可以通过 root sync 恢复。
- 单 root-miner 或隔离网络中，该 shard 可能停止被 root block 确认。

## 修改内容

- 移除 minor block commit marker。
- root sync 只请求 master 缺少 mheader 的 minor block。
- slave 复用本地 body，只下载缺失 body，按 block height 排序后交给 shard force replay。
- 增加 master mheader 去重。
- 普通 root reorg 保留 body；`SetHead/reset` 和跨 genesis root fork 保持删除语义。
- `CheckMinorBlock` 改为只验证、不写数据库。
- 修复 `AddRootBlock` 在 minor header 对应的 previous root block 不存在时的 nil dereference。

## 测试

- 单元测试：
  - 添加相应 UT，并运行 `go test ./...`。
- 节点测试：
  - 节点从高度 0 同步到最新高度。
  - 节点停止并重启后继续同步和出块。
